### PR TITLE
Fix codegen object flag sizing bug

### DIFF
--- a/integration_tests/device_configs/example1.toml
+++ b/integration_tests/device_configs/example1.toml
@@ -66,6 +66,7 @@ object_type = "var"
 parameter_name = "u32 var"
 data_type = "uint32"
 access_type = "rw"
+pdo_mapping = "tpdo"
 
 [[objects]]
 index = 0x3003
@@ -101,3 +102,30 @@ parameter_name = "Domain"
 object_type = "var"
 data_type = "domain"
 access_type = "rw"
+
+[[objects]]
+index = 0x3008
+parameter_name = "Array of size 7"
+object_type = "array"
+array_size = 7
+data_type = "uint8"
+access_type = "rw"
+pdo_mapping = "both"
+
+[[objects]]
+index = 0x3009
+parameter_name = "Array of size 8"
+object_type = "array"
+array_size = 8
+data_type = "uint8"
+access_type = "rw"
+pdo_mapping = "both"
+
+[[objects]]
+index = 0x300A
+parameter_name = "Array of size 9"
+object_type = "array"
+array_size = 9
+data_type = "uint8"
+access_type = "rw"
+pdo_mapping = "both"

--- a/integration_tests/tests/object_flags_test.rs
+++ b/integration_tests/tests/object_flags_test.rs
@@ -1,0 +1,37 @@
+use integration_tests::object_dict1::{NODE_STATE, OBJECT3008, OBJECT3009, OBJECT300A};
+use zencan_node::object_dict::ObjectAccess;
+
+#[test]
+fn test_event_flags() {
+    fn test_event_flags(obj: &dyn ObjectAccess, n: u8) {
+        // No flags set after toggle
+        NODE_STATE.pdo_sync().toggle();
+        for i in 0..n {
+            assert!(!obj.read_event_flag(i));
+        }
+        // Set all the flags on the object
+        for i in 0..n {
+            obj.set_event_flag(i).unwrap();
+        }
+
+        // Toggle and read back set flags
+        NODE_STATE.pdo_sync().toggle();
+        for i in 0..n {
+            assert!(obj.read_event_flag(i));
+        }
+
+        // Set only the first flag
+        obj.set_event_flag(0).unwrap();
+
+        // Toggle and check they are cleared, except the first
+        NODE_STATE.pdo_sync().toggle();
+
+        for i in 0..n {
+            assert_eq!(i == 0, obj.read_event_flag(i));
+        }
+    }
+
+    test_event_flags(&OBJECT3008, 7);
+    test_event_flags(&OBJECT3009, 8);
+    test_event_flags(&OBJECT300A, 9);
+}

--- a/zencan-build/src/codegen.rs
+++ b/zencan-build/src/codegen.rs
@@ -185,7 +185,7 @@ fn generate_object_definition(obj: &ObjectDefinition) -> Result<TokenStream, Com
     }
 
     if tpdo_mapping {
-        let n = (highest_sub_index as usize).div_ceil(8);
+        let n = (highest_sub_index as usize + 1).div_ceil(8);
         field_tokens.extend(quote! {
             flags: ObjectFlags<#n>,
         });


### PR DESCRIPTION
Object definition was generated with 0-sized object flags for TPDO mappable objects with size 1. 

This slipped through tests because there were no such objects in the integration test example configs. This adds a breaking example and some further tests around the object flags. This resolves issue #17 