### PR TITLE
Cli command execution and PDO scan

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ zencan-node = { path = "zencan-node" }
 # External
 crc16 = "0.4.0"
 critical-section = { version = "1.2.0", default-features = false }
-crossbeam = { version = "0.8.4", default-features = false }
 defmt = "1.0.1"
 defmt-or-log = { version = "0.2.1", default-features = false }
 embedded-io = { version = "0.6.1" }

--- a/examples/socketcan_node/example_pdo_config.toml
+++ b/examples/socketcan_node/example_pdo_config.toml
@@ -1,0 +1,9 @@
+ [tpdo.0]
+ enabled = true
+ cob = 0x800
+ extended = true
+ transmission_type = 254
+ mappings = [
+     { index=0x2000, sub=0, size=16 },
+     { index=0x2001, sub=1, size=16 },
+ ]

--- a/integration_tests/tests/pdo_tests.rs
+++ b/integration_tests/tests/pdo_tests.rs
@@ -264,7 +264,7 @@ async fn test_pdo_configuration() {
 
     let test_task = async move {
         let config = PdoConfig {
-            cob: 0x301,
+            cob: CanId::std(0x301),
             enabled: true,
             mappings: vec![
                 PdoMapping {

--- a/zencan-cli/Cargo.toml
+++ b/zencan-cli/Cargo.toml
@@ -29,3 +29,6 @@ tokio = { version = "1.45.0", features = ["net", "macros", "rt-multi-thread"] }
 reedline = "0.40.0"
 shlex = "1.3.0"
 clap-num = "1.2.0"
+
+[dev-dependencies]
+assertables = "9.8.2"

--- a/zencan-cli/src/command.rs
+++ b/zencan-cli/src/command.rs
@@ -17,6 +17,8 @@ pub enum Commands {
     Write(WriteArgs),
     /// Scan all node IDs to find configured devices
     Scan,
+    /// Scan the PDO configuration from a node
+    ScanPdoConfig(ScanPdoConfigArgs),
     /// Print info about nodes
     Info,
     /// Load a configuration from a file to a node
@@ -70,6 +72,11 @@ pub struct WriteArgs {
     pub data_type: SdoDataType,
     /// The value to write
     pub value: String,
+}
+
+#[derive(Debug, Args)]
+pub struct ScanPdoConfigArgs {
+    pub node_id: u8,
 }
 
 #[derive(Debug, Args)]

--- a/zencan-client/Cargo.toml
+++ b/zencan-client/Cargo.toml
@@ -31,6 +31,9 @@ tokio = { version = "1.45.0", features = [
 toml = "0.8.22"
 serde = { version = "1.0.219", features = ["derive"] }
 
+[dev-dependencies]
+assertables = "9.8.2"
+
 # docs.rs-specific configuration
 [package.metadata.docs.rs]
 # defines the configuration attribute `docsrs`

--- a/zencan-client/src/bus_manager/bus_manager.rs
+++ b/zencan-client/src/bus_manager/bus_manager.rs
@@ -120,7 +120,6 @@ async fn scan_node<S: AsyncCanSender + Sync + Send>(
     };
     let device_name = match sdo_client.read_device_name().await {
         Ok(s) => Some(s),
-        Err(SdoClientError::NoResponse) => return None,
         Err(e) => {
             log::error!("SDO Abort Response scanning node {node_id} device name: {e:?}");
             None

--- a/zencan-common/src/constants.rs
+++ b/zencan-common/src/constants.rs
@@ -16,6 +16,16 @@ pub mod object_ids {
     pub const HEARTBEAT_PRODUCER_TIME: u16 = 0x1017;
     /// The identity object index
     pub const IDENTITY: u16 = 0x1018;
+
+    /// The first RPDO communication parameter index. RPDO comm can be stored from 0x1400 to 0x15FF.
+    pub const RPDO_COMM_BASE: u16 = 0x1400;
+    ///  The first RPDO mapping parameter index. RPDO mappings can be stored from 0x1600 to 0x17FF;
+    pub const RPDO_MAP_BASE: u16 = 0x1600;
+    /// The first TPDO communication parameter index. TPDO comms can be stored from 0x1800 to 0x19FF.
+    pub const TPDO_COMM_BASE: u16 = 0x1800;
+    ///  The first TPDO mapping parameter index. TPDO mappings can be stored from 0x1A00 to 0x1BFF;
+    pub const TPDO_MAP_BASE: u16 = 0x1A00;
+
     /// The auto start object index
     pub const AUTO_START: u16 = 0x5000;
 }

--- a/zencan-common/src/messages.rs
+++ b/zencan-common/src/messages.rs
@@ -18,6 +18,15 @@ pub enum CanId {
     Std(u16),
 }
 
+impl core::fmt::Display for CanId {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            CanId::Extended(id) => write!(f, "Extended(0x{id:x})"),
+            CanId::Std(id) => write!(f, "Std(0x{id:x})"),
+        }
+    }
+}
+
 impl CanId {
     /// Create a new extended ID
     pub const fn extended(id: u32) -> CanId {


### PR DESCRIPTION
Add the scan-pdo-config to read out the PDO configuration from a node, and add the -c/--command option to `zencan-cli` to allow for executing a single command without launching the interactive CLI. 



