### PR TITLE
[zencan-client] Fix overflow on receive channel and leaked task

### DIFF
--- a/zencan-client/Cargo.toml
+++ b/zencan-client/Cargo.toml
@@ -30,6 +30,7 @@ tokio = { version = "1.45.0", features = [
 ] }
 toml = "0.8.22"
 serde = { version = "1.0.219", features = ["derive"] }
+tokio-util = "0.7.16"
 
 [dev-dependencies]
 assertables = "9.8.2"


### PR DESCRIPTION
- SdoClientMutex was keeping a SharedReceiverChannel, but never reading from it. This resulted in logged overflow warnings. Instead, make SharedReceiver cloneable and let SdoClientMutex keep that instead of a channel.
- The spawned task never exited, now a cancellation token is used to end the task when all SharedReceiver clones are dropped.