### PR TITLE
[common] Remove socketcan fork dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,5 @@ heapless = "0.8.0"
 log = "0.4.27"
 serde = { version = "1.0.219", features = ["derive"] }
 snafu = { version = "0.8.5", default-features = false }
-socketcan = { version = "3.5.0", features = [
-    "tokio",
-], git = "https://github.com/mcbridejc/socketcan-rs" }
+socketcan = { version = "3.5.0", features = ["tokio"] }
 toml = "0.8.20"

--- a/zencan-common/Cargo.toml
+++ b/zencan-common/Cargo.toml
@@ -19,6 +19,7 @@ regex = { version = "1.11.1", optional = true }
 serde = { workspace = true, optional = true }
 snafu.workspace = true
 socketcan = { workspace = true, optional = true }
+tokio = { version = "1.47.1", features = ["net"], optional = true }
 toml = { workspace = true, optional = true }
 
 [dev-dependencies]
@@ -27,7 +28,7 @@ assertables = "9.8.0"
 [features]
 default = ["socketcan", "std", "log"]
 std = ["critical-section/std", "snafu/std", "dep:toml", "dep:regex", "dep:serde"]
-socketcan = ["dep:socketcan", "std"]
+socketcan = ["dep:socketcan", "dep:tokio", "std"]
 defmt = ["defmt-or-log/defmt", "dep:defmt"]
 log = ["defmt-or-log/log"]
 


### PR DESCRIPTION
Implement AsyncCanSocket wrapper around socketcan socket in zencan-common to remove the dependency on forked socketcan.

Can remove later if https://github.com/socketcan-rs/socketcan-rs/pull/84 gets incorporated upstream. 