### PR TITLE
Add time of day type as ByteField with 6 bytes.

### DIFF
--- a/zencan-build/src/codegen.rs
+++ b/zencan-build/src/codegen.rs
@@ -42,6 +42,7 @@ fn get_storage_type(data_type: DCDataType) -> (syn::Type, usize) {
         ),
         DCDataType::OctetString(n) => (syn::parse_str(&format!("ByteField::<{}>", n)).unwrap(), n),
         DCDataType::Domain => (syn::parse_quote!(CallbackSubObject), 0),
+        DCDataType::TimeOfDay => (syn::parse_str("ByteField::<6>").unwrap(), 6),
         _ => panic!("Unsupported data type {:?}", data_type),
     }
 }
@@ -60,6 +61,7 @@ fn get_rust_type_and_size(data_type: DCDataType) -> (syn::Type, usize) {
         | DCDataType::OctetString(n)
         | DCDataType::UnicodeString(n) => (syn::parse_str(&format!("[u8; {}]", n)).unwrap(), n),
         DCDataType::Domain => (syn::parse_quote!(None), 0),
+        DCDataType::TimeOfDay => (syn::parse_str("[u8; 6]").unwrap(), 6),
         _ => panic!("Unsupported data type {:?}", data_type),
     }
 }
@@ -238,7 +240,10 @@ fn get_default_tokens(
             }
             let byte_lit = string_to_byte_literal_tokens(s, data_type.size())?;
             // OctetStrings are always the exact length
-            if matches!(data_type, DCDataType::OctetString(_)) {
+            if matches!(
+                data_type,
+                DCDataType::OctetString(_) | DCDataType::TimeOfDay
+            ) {
                 Ok(quote!(ByteField::new(#byte_lit)))
             } else {
                 Ok(quote!(NullTermByteField::new(#byte_lit)))

--- a/zencan-common/src/device_config.rs
+++ b/zencan-common/src/device_config.rs
@@ -906,7 +906,10 @@ impl DataType {
     pub fn is_str(&self) -> bool {
         matches!(
             self,
-            DataType::VisibleString(_) | DataType::OctetString(_) | DataType::UnicodeString(_)
+            DataType::VisibleString(_)
+                | DataType::OctetString(_)
+                | DataType::UnicodeString(_)
+                | DataType::TimeOfDay
         )
     }
 
@@ -924,8 +927,8 @@ impl DataType {
             DataType::VisibleString(size) => *size,
             DataType::OctetString(size) => *size,
             DataType::UnicodeString(size) => *size,
-            DataType::TimeOfDay => 4,
-            DataType::TimeDifference => 4,
+            DataType::TimeOfDay => 6,
+            DataType::TimeDifference => 6,
             DataType::Domain => 0, // Domain size is variable
         }
     }


### PR DESCRIPTION
This doesn't have any parsing between milliseconds after midnight (4 bytes) and days after 1984 (2 bytes), happy to add that if you can point me to where in the code that should be done. Not sure what the best type for an application to use would be, maybe `chrono::DateTime<Utc>`?

Also are there tests that I should add?