### PR TITLE
Fix SDO server bugs

### DIFF
--- a/zencan-node/src/sdo_server/sdo_server.rs
+++ b/zencan-node/src/sdo_server/sdo_server.rs
@@ -499,19 +499,10 @@ impl<'a> SdoState<'a> {
                     })
                 };
 
-                let response =
-                    SdoResponse::upload_segment(state.toggle_state, c, &msg_buf[0..segment_size]);
-
-                if c {
-                    SdoResult::response_with_update(
-                        response,
-                        state.object.index,
-                        state.sub,
-                        new_state,
-                    )
-                } else {
-                    SdoResult::response(response, new_state)
-                }
+                SdoResult::response(
+                    SdoResponse::upload_segment(state.toggle_state, c, &msg_buf[0..segment_size]),
+                    new_state,
+                )
             }
             SdoRequest::Abort {
                 index: _,


### PR DESCRIPTION
This fixes two issues, one major, one minor: 
- The major one is that segmented upload was very broken. When process was called without a new SdoRequest, the state erroneously changed from UploadSegmented to DownloadSegmented, resulting in an Abort of the transfer.
- The minor one is that segmented uploads were returning the updated object index, when they should not have (the upload is a read, it does not update the object). 