### PR TITLE
Add support for f64, u64, i64, TimeOfDay, TimeDifference objects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ embedded-io = { version = "0.6.1" }
 futures = { version = "0.3.31", default-features = false, features = [
     "async-await",
 ] }
-heapless = "0.8.0"
 log = "0.4.27"
 serde = { version = "1.0.219", features = ["derive"] }
 snafu = { version = "0.8.5", default-features = false }

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -17,6 +17,7 @@ critical-section = { version = "1.2.0", features = ["std"] }
 embedded-io.workspace = true
 futures.workspace = true
 tokio = { version = "1.44.2", features = ["rt", "macros", "time", "sync"] }
+rand = "0.9.2"
 
 [dev-dependencies]
 assertables = "9.8.1"

--- a/integration_tests/device_configs/example1.toml
+++ b/integration_tests/device_configs/example1.toml
@@ -148,3 +148,72 @@ array_size = 9
 data_type = "uint8"
 access_type = "rw"
 pdo_mapping = "both"
+
+[[objects]]
+index = 0x300B
+parameter_name = "Time Objects"
+object_type = "record"
+[[objects.subs]]
+sub_index = 1
+data_type = "TimeOfDay"
+access_type = "rw"
+pdo_mapping = "tpdo"
+[[objects.subs]]
+sub_index = 2
+data_type = "TimeDifference"
+access_type = "rw"
+
+[[objects]]
+index = 0x300C
+parameter_name = "All The Numbers"
+object_type = "record"
+[[objects.subs]]
+sub_index = 1
+data_type = "uint8"
+access_type = "rw"
+pdo_mapping = "both"
+[[objects.subs]]
+sub_index = 2
+data_type = "uint16"
+access_type = "rw"
+pdo_mapping = "both"
+[[objects.subs]]
+sub_index = 3
+data_type = "uint32"
+access_type = "rw"
+pdo_mapping = "both"
+[[objects.subs]]
+sub_index = 4
+data_type = "uint64"
+access_type = "rw"
+pdo_mapping = "both"
+[[objects.subs]]
+sub_index = 5
+data_type = "int8"
+access_type = "rw"
+pdo_mapping = "both"
+[[objects.subs]]
+sub_index = 6
+data_type = "int16"
+access_type = "rw"
+pdo_mapping = "both"
+[[objects.subs]]
+sub_index = 7
+data_type = "int32"
+access_type = "rw"
+pdo_mapping = "both"
+[[objects.subs]]
+sub_index = 8
+data_type = "int64"
+access_type = "rw"
+pdo_mapping = "both"
+[[objects.subs]]
+sub_index = 9
+data_type = "real32"
+access_type = "rw"
+pdo_mapping = "both"
+[[objects.subs]]
+sub_index = 10
+data_type = "real64"
+access_type = "rw"
+pdo_mapping = "both"

--- a/zencan-build/src/lib.rs
+++ b/zencan-build/src/lib.rs
@@ -191,6 +191,6 @@ mod tests {
         let out_file = NamedTempFile::new().expect("Failed to create tempfile");
         let err = compile_device_config(input_file.path(), out_file.path());
         assert!(err.is_err());
-        assert_contains!(err.unwrap_err().to_string(), "DefaultValueTypeMismatch: Default value 0 is not a valid value for type VisibleString(16)");
+        assert_contains!(err.unwrap_err().to_string(), "DefaultValueTypeMismatch: Default integer value 0 is not a valid value for type VisibleString(16)");
     }
 }

--- a/zencan-client/Cargo.toml
+++ b/zencan-client/Cargo.toml
@@ -31,6 +31,7 @@ tokio = { version = "1.45.0", features = [
 toml = "0.8.22"
 serde = { version = "1.0.219", features = ["derive"] }
 tokio-util = "0.7.16"
+paste = "1.0.15"
 
 [dev-dependencies]
 assertables = "9.8.2"

--- a/zencan-common/Cargo.toml
+++ b/zencan-common/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+chrono = { version = "0.4.42", default-features = false }
 critical-section.workspace = true
 defmt = { workspace = true, optional = true }
 defmt-or-log = { workspace = true, default-features = false, features = ["at_least_one"] }
@@ -27,7 +28,7 @@ assertables = "9.8.0"
 
 [features]
 default = ["socketcan", "std", "log"]
-std = ["critical-section/std", "snafu/std", "dep:toml", "dep:regex", "dep:serde"]
+std = ["critical-section/std", "snafu/std", "chrono/std", "dep:toml", "dep:regex", "dep:serde"]
 socketcan = ["dep:socketcan", "dep:tokio", "std"]
 defmt = ["defmt-or-log/defmt", "dep:defmt"]
 log = ["defmt-or-log/log"]

--- a/zencan-common/src/device_config.rs
+++ b/zencan-common/src/device_config.rs
@@ -946,11 +946,14 @@ pub enum DataType {
     Int8,
     Int16,
     Int32,
+    Int64,
     #[default]
     UInt8,
     UInt16,
     UInt32,
+    UInt64,
     Real32,
+    Real64,
     VisibleString(usize),
     OctetString(usize),
     UnicodeString(usize),
@@ -975,10 +978,13 @@ impl DataType {
             DataType::Int8 => 1,
             DataType::Int16 => 2,
             DataType::Int32 => 4,
+            DataType::Int64 => 8,
             DataType::UInt8 => 1,
             DataType::UInt16 => 2,
             DataType::UInt32 => 4,
+            DataType::UInt64 => 8,
             DataType::Real32 => 4,
+            DataType::Real64 => 8,
             DataType::VisibleString(size) => *size,
             DataType::OctetString(size) => *size,
             DataType::UnicodeString(size) => *size,
@@ -1007,14 +1013,20 @@ impl<'de> serde::Deserialize<'de> for DataType {
             Ok(DataType::Int16)
         } else if s == "int32" {
             Ok(DataType::Int32)
+        } else if s == "int64" {
+            Ok(DataType::Int64)
         } else if s == "uint8" {
             Ok(DataType::UInt8)
         } else if s == "uint16" {
             Ok(DataType::UInt16)
         } else if s == "uint32" {
             Ok(DataType::UInt32)
+        } else if s == "uint64" {
+            Ok(DataType::UInt64)
         } else if s == "real32" {
             Ok(DataType::Real32)
+        } else if s == "real64" {
+            Ok(DataType::Real64)
         } else if let Some(caps) = re_visiblestring.captures(&s) {
             let size: usize = caps[1].parse().map_err(|_| {
                 D::Error::custom(format!("Invalid size for VisibleString: {}", &caps[1]))

--- a/zencan-common/src/lib.rs
+++ b/zencan-common/src/lib.rs
@@ -21,6 +21,7 @@ pub mod node_id;
 pub mod objects;
 pub mod pdo;
 pub mod sdo;
+mod time_types;
 pub mod traits;
 
 #[cfg(feature = "socketcan")]
@@ -30,6 +31,6 @@ mod socketcan;
 #[cfg_attr(docsrs, doc(cfg(feature = "socketcan")))]
 pub use socketcan::open_socketcan;
 
-pub use node_id::NodeId;
-
 pub use messages::{CanError, CanId, CanMessage};
+pub use node_id::NodeId;
+pub use time_types::{TimeDifference, TimeOfDay};

--- a/zencan-common/src/objects.rs
+++ b/zencan-common/src/objects.rs
@@ -145,6 +145,12 @@ pub enum DataType {
     /// An arbitrary byte access type for e.g. data streams, or large chunks of
     /// data. Size is typically not known at build time.
     Domain = 0xf,
+    /// A 64-bit floating point value
+    Real64 = 0x11,
+    /// A signed 64-bit integer
+    Int64 = 0x15,
+    /// An unsigned 64-bit integer
+    UInt64 = 0x1b,
     /// A contained for an unrecognized data type value
     Other(u16),
 }

--- a/zencan-common/src/time_types.rs
+++ b/zencan-common/src/time_types.rs
@@ -1,0 +1,177 @@
+//! Data types for TimeOfDay and TimeDifference fields
+
+use chrono::{Datelike, NaiveDate, NaiveTime, TimeDelta, Timelike};
+use core::time::Duration;
+use snafu::Snafu;
+
+const MILLIS_PER_DAY: u64 = 86_400_000;
+
+#[derive(Clone, Copy, Debug, Snafu)]
+pub enum TimeCreateError {
+    /// The provided time is before the epoch and cannot be represented
+    PreEpoch,
+    /// The provided is too far into the future to be represented by TimeOfDay
+    OutOfRange,
+    /// The provided date is invalid
+    ///
+    /// This likely means that the date you specified does not exist or is outside the range which
+    /// can be be represented by chrono::NaiveDate
+    InvalidDate,
+}
+
+/// Represents a time in 48-bits, as stored in TimeOfDay objects
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TimeOfDay(TimeDifference);
+
+impl TimeOfDay {
+    /// The size of a TimeOfDay object in bytes as stored in the object dict
+    pub const SIZE: usize = 6;
+
+    /// A zero-inintialized TimeOfDay corresponding to the TimeOfDay epoch of 1984-01-01
+    pub const EPOCH: TimeOfDay = TimeOfDay(TimeDifference { ms: 0, days: 0 });
+    // TimeOfDay objects are encoded with reference to 1984-01-01
+    const CHRONO_EPOCH: NaiveDate = NaiveDate::from_ymd_opt(1984, 1, 1).unwrap();
+
+    /// Create a new TimeOfDay
+    ///
+    /// # Arguments
+    /// - `days`: The number of days since January 1, 1984
+    /// - `ms`: The number of milliseconds after midnight
+    pub fn new(days: u16, ms: u32) -> Self {
+        Self(TimeDifference::new(days, ms))
+    }
+
+    /// Create a TimeOfDay corresponding to the provided date and time
+    pub fn from_ymd_hms_ms(
+        year: u32,
+        month: u32,
+        day: u32,
+        hour: u32,
+        min: u32,
+        sec: u32,
+        milli: u32,
+    ) -> Result<Self, TimeCreateError> {
+        let chrono_date = NaiveDate::from_ymd_opt(year as i32, month, day)
+            .ok_or(InvalidDateSnafu.build())?
+            .and_hms_milli_opt(hour, min, sec, milli)
+            .ok_or(InvalidDateSnafu.build())?;
+
+        let delta = chrono_date - const { Self::CHRONO_EPOCH.and_hms_opt(0, 0, 0).unwrap() };
+        let days = delta.num_days();
+        let ms = (delta - TimeDelta::days(days)).num_milliseconds();
+        if days < 0 {
+            PreEpochSnafu.fail()
+        } else if days > u16::MAX as i64 {
+            OutOfRangeSnafu.fail()
+        } else {
+            Ok(Self::new(days as u16, ms as u32))
+        }
+    }
+
+    /// Create a TimeOfDay from little endian bytes
+    pub fn from_le_bytes(bytes: [u8; 6]) -> Self {
+        Self(TimeDifference::from_le_bytes(bytes))
+    }
+
+    /// Get the little endian byte representation of the time of day
+    pub fn to_le_bytes(&self) -> [u8; 6] {
+        self.0.to_le_bytes()
+    }
+
+    /// Get the date represented
+    ///
+    /// Returns (year, month, day)
+    pub fn date_ymd(&self) -> (u32, u32, u32) {
+        let date = Self::CHRONO_EPOCH + self.0.as_chrono_delta();
+        (date.year() as u32, date.month(), date.day())
+    }
+
+    /// Get the date as number of days since 1984-01-01
+    pub fn days(&self) -> u16 {
+        self.0.days
+    }
+
+    /// Get the time of day as (hour, min, sec, millis)
+    pub fn time_hmsm(&self) -> (u32, u32, u32, u32) {
+        let sec = self.0.ms / 1000;
+        let nanos = (self.0.ms % 1000) * 1000;
+        let t = NaiveTime::from_num_seconds_from_midnight_opt(sec, nanos).unwrap();
+        (t.hour(), t.minute(), t.second(), t.nanosecond() / 1000)
+    }
+
+    /// Get the time of day as the number of milliseconds since midnight
+    pub fn time_millis(&self) -> u32 {
+        self.0.ms
+    }
+
+    /// Get the time of of day as a [`Duration`] since midnight
+    pub fn time_duration(&self) -> Duration {
+        Duration::from_millis(self.time_millis() as u64)
+    }
+
+    /// Get the total number of milliseconds since 1984-01-01
+    pub fn total_millis(&self) -> u64 {
+        self.0.total_millis()
+    }
+
+    /// Get the time represented as a SystemTime
+    #[cfg(feature = "std")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "std")))]
+    pub fn as_system_time(&self) -> std::time::SystemTime {
+        use std::time::SystemTime;
+
+        // System time is relative to the UNIX_EPOCH of 1970-01-01
+        const UNIX_EPOCH: NaiveDate = NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
+        let epoch_delta_millis = (Self::CHRONO_EPOCH - UNIX_EPOCH).num_milliseconds() as u64;
+        SystemTime::UNIX_EPOCH + self.0.as_duration() + Duration::from_millis(epoch_delta_millis)
+    }
+}
+
+/// Represents a duration of time in 48-bits, as stored in TimeDifference objects
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct TimeDifference {
+    ms: u32,
+    days: u16,
+}
+
+impl TimeDifference {
+    /// The size of a TimeDifference object in bytes as stored in the object dict
+    pub const SIZE: usize = 6;
+
+    /// A zero time difference
+    pub const ZERO: TimeDifference = TimeDifference { ms: 0, days: 0 };
+
+    /// Create a new time difference from the raw u32 value
+    pub const fn new(days: u16, ms: u32) -> Self {
+        Self { ms, days }
+    }
+
+    /// Create a TimeOfDay from little endian bytes
+    pub fn from_le_bytes(bytes: [u8; 6]) -> Self {
+        let ms = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
+        let days = u16::from_le_bytes(bytes[4..6].try_into().unwrap());
+        Self::new(days, ms)
+    }
+
+    /// Return the little endian byte representation of the TimeDifference
+    pub fn to_le_bytes(&self) -> [u8; 6] {
+        let mut bytes = [0; 6];
+        bytes[0..4].copy_from_slice(&self.ms.to_le_bytes());
+        bytes[4..6].copy_from_slice(&self.days.to_le_bytes());
+        bytes
+    }
+
+    /// Get the time duration as milliseconds
+    pub fn total_millis(&self) -> u64 {
+        self.days as u64 * MILLIS_PER_DAY + self.ms as u64
+    }
+
+    /// Convert to a [`core::time::Duration`]
+    pub fn as_duration(&self) -> Duration {
+        Duration::from_millis(self.days as u64 * MILLIS_PER_DAY + self.ms as u64)
+    }
+
+    pub(crate) fn as_chrono_delta(&self) -> chrono::TimeDelta {
+        chrono::TimeDelta::milliseconds(self.days as i64 * MILLIS_PER_DAY as i64 + self.ms as i64)
+    }
+}


### PR DESCRIPTION
Closes #4 

### Bonus Changes

- macro_rules to DRY up the repetitive `upload_u8`/`download_u8` etc methods on `SdoClient`
- fix bug where record sub object accessors were being named in hex (`get_suba()` instead of `get_sub10()`)