### PR TITLE
Embedded-io to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ crc16 = "0.4.0"
 critical-section = { version = "1.2.0", default-features = false }
 defmt = "1.0.1"
 defmt-or-log = { version = "0.2.1", default-features = false }
-embedded-io = { version = "0.6.1" }
+embedded-io = { version = "0.7.1" }
 futures = { version = "0.3.31", default-features = false, features = [
     "async-await",
 ] }

--- a/examples/stm32g0-lilos-node/Cargo.toml
+++ b/examples/stm32g0-lilos-node/Cargo.toml
@@ -15,7 +15,7 @@ cortex-m = { version = "0.7.4", features=["critical-section-single-core"] }
 cortex-m-rt = "0.7.5"
 critical-section = "1.2.0"
 defmt = "1.0.1"
-embedded-io = "0.6.1"
+embedded-io = "0.7.1"
 fdcan = { version = "0.2.1", features = ["fdcan_g0_g4_l5"] }
 stm32-metapac = { version = "15.0.0", features = ["stm32g0b1cb", "rt"] }
 hash32 = "1.0.0"

--- a/zencan-common/src/device_config.rs
+++ b/zencan-common/src/device_config.rs
@@ -870,7 +870,6 @@ pub struct DomainDefinition {}
 
 /// Descriptor for an object in the object dictionary
 #[derive(Deserialize, Debug, Clone)]
-#[serde(deny_unknown_fields)]
 pub struct ObjectDefinition {
     /// The index of the object
     pub index: u16,

--- a/zencan-common/src/device_config.rs
+++ b/zencan-common/src/device_config.rs
@@ -549,6 +549,7 @@ pub enum AutoStartConfig {
 
 /// Represents the configuration parameters for a single PDO
 #[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct PdoDefaultConfig {
     /// The COB ID this PDO will use to send/receive
     pub cob_id: u32,
@@ -586,6 +587,7 @@ impl From<PdoDefaultConfigMapSerializer> for HashMap<usize, PdoDefaultConfig> {
 
 /// Private struct for deserializing [pdos] section of device config TOML
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct DevicePdoConfigSerializer {
     #[serde(default = "default_num_rpdo")]
     /// The number of TX PDO slots available in the device. Defaults to 4.
@@ -658,6 +660,7 @@ pub struct IdentityConfig {
 
 /// Configuration object to define a programmable bootloader section
 #[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct BootloaderSection {
     /// Name of the section
     pub name: String,
@@ -667,6 +670,7 @@ pub struct BootloaderSection {
 
 /// Configuration of bootloader parameters
 #[derive(Clone, Deserialize, Debug, Default)]
+#[serde(deny_unknown_fields)]
 pub struct BootloaderConfig {
     /// If true, this node is an application which supports resetting to a bootloader, rather than a
     /// bootloader implementation
@@ -866,6 +870,7 @@ pub struct DomainDefinition {}
 
 /// Descriptor for an object in the object dictionary
 #[derive(Deserialize, Debug, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct ObjectDefinition {
     /// The index of the object
     pub index: u16,

--- a/zencan-node/src/lib.rs
+++ b/zencan-node/src/lib.rs
@@ -213,6 +213,7 @@ pub use zencan_macro::build_object_dict;
 // Re-export types used by generated code
 pub use critical_section;
 pub use zencan_common as common;
+pub use embedded_io;
 
 pub use bootloader::{BootloaderInfo, BootloaderSection, BootloaderSectionCallbacks};
 #[cfg(feature = "socketcan")]

--- a/zencan-node/src/lib.rs
+++ b/zencan-node/src/lib.rs
@@ -212,8 +212,8 @@ pub use zencan_macro::build_object_dict;
 
 // Re-export types used by generated code
 pub use critical_section;
-pub use zencan_common as common;
 pub use embedded_io;
+pub use zencan_common as common;
 
 pub use bootloader::{BootloaderInfo, BootloaderSection, BootloaderSectionCallbacks};
 #[cfg(feature = "socketcan")]


### PR DESCRIPTION
Update embedded_io to 0.7, and re-export it for applications to use. I ran into some issues with mixed 0.6 and 0.7, and it helps to re-export so that applications can create wrappers based on the zencan version and be less brittle. 

Also, add deny_unknown_fields to those serialization structs in device config which were lacking it.