### PR TITLE
fix : build failed on mac / win

### DIFF
--- a/examples/socketcan_node/src/main.rs
+++ b/examples/socketcan_node/src/main.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(target_os = "linux"), allow(unused_imports, dead_code))]
 use std::{
     convert::Infallible,
     io::Write as _,
@@ -16,6 +17,7 @@ use zencan_node::{
     Callbacks,
 };
 
+#[cfg(target_os = "linux")]
 use zencan_node::open_socketcan;
 
 mod zencan {
@@ -33,6 +35,12 @@ struct Args {
     serial: Option<u32>,
 }
 
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    println!("socketcan_node can only run on linux");
+}
+
+#[cfg(target_os = "linux")]
 #[tokio::main]
 async fn main() {
     // Initialize the logger

--- a/zencan-cli/Cargo.toml
+++ b/zencan-cli/Cargo.toml
@@ -18,7 +18,7 @@ path = "src/bin/zencan-cli.rs"
 
 [dependencies]
 # Local
-zencan-client.workspace = true
+zencan-client = { workspace = true, features = ["socketcan"] }
 
 # External
 clap = { version = "4.5.37", features = ["derive"] }

--- a/zencan-cli/src/bin/zencan-cli.rs
+++ b/zencan-cli/src/bin/zencan-cli.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(target_os = "linux"), allow(unused_imports, dead_code))]
 //! A REPL-style interactive shell for talking to CAN devices via socketcan
 use std::{
     array::TryFromSliceError,
@@ -23,8 +24,11 @@ use zencan_client::{
         lss::LssState, node_configuration::NodeConfig, node_id::ConfiguredNodeId,
         traits::AsyncCanSender, NodeId,
     },
-    open_socketcan, BusManager,
+    BusManager,
 };
+
+#[cfg(target_os = "linux")]
+use zencan_client::open_socketcan;
 
 #[derive(Parser)]
 struct Args {
@@ -486,6 +490,12 @@ fn parse_command(line: &str) -> Result<Cli, clap::Error> {
     }
 }
 
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    println!("zencan-cli uses socketcan, so currently only works on linux.");
+}
+
+#[cfg(target_os = "linux")]
 #[tokio::main]
 async fn main() {
     env_logger::init();
@@ -494,6 +504,7 @@ async fn main() {
     let node_state = Arc::new(Mutex::new(0));
     let prompt = ZencanPrompt::new(&args.socket, node_state.clone());
 
+    #[cfg(target_os = "linux")]
     let (tx, rx) = open_socketcan(&args.socket).expect("Failed to open bus socket");
     let mut manager = BusManager::new(tx, rx);
 

--- a/zencan-cli/src/bin/zencandump.rs
+++ b/zencan-cli/src/bin/zencandump.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(target_os = "linux"), allow(unused_imports))]
 use clap::Parser;
 use zencan_client::common::{
     messages::{MessageError, ZencanMessage},
@@ -31,6 +32,12 @@ impl From<CanMessage> for Message {
     }
 }
 
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    println!("zencandump uses socketcan, so currently only works on linux.");
+}
+
+#[cfg(target_os = "linux")]
 #[tokio::main]
 async fn main() {
     let args = Args::parse();

--- a/zencan-client/Cargo.toml
+++ b/zencan-client/Cargo.toml
@@ -13,14 +13,13 @@ repository.workspace = true
 
 [dependencies]
 # Internal
-zencan-common = { workspace = true, features = ["socketcan", "log"] }
+zencan-common = { workspace = true, default-features = false, features = ["log", "std"] }
 
 # External
 crc16.workspace = true
-futures.workspace = true
-log.workspace = true
+futures = {workspace = true, features = ["std"]}
+log = { workspace = true, optional = true }
 snafu.workspace = true
-socketcan.workspace = true
 tokio = { version = "1.45.0", features = [
     "net",
     "time",
@@ -33,8 +32,16 @@ serde = { version = "1.0.219", features = ["derive"] }
 tokio-util = "0.7.16"
 paste = "1.0.15"
 
+[target.'cfg(target_os = "linux")'.dependencies]
+socketcan.workspace = true
+zencan-common = { workspace = true, features = ["socketcan"] }
+
 [dev-dependencies]
 assertables = "9.8.2"
+
+[features]
+default = ["log"]
+socketcan = ["zencan-common/socketcan"]
 
 # docs.rs-specific configuration
 [package.metadata.docs.rs]

--- a/zencan-client/src/lib.rs
+++ b/zencan-client/src/lib.rs
@@ -29,6 +29,7 @@ mod sdo_client;
 pub use zencan_common as common;
 
 pub use bus_manager::BusManager;
+#[cfg(feature = "socketcan")]
 pub use common::open_socketcan;
 pub use lss_master::{LssError, LssMaster};
 pub use sdo_client::{RawAbortCode, SdoClient, SdoClientError};

--- a/zencan-client/src/lib.rs
+++ b/zencan-client/src/lib.rs
@@ -29,7 +29,7 @@ mod sdo_client;
 pub use zencan_common as common;
 
 pub use bus_manager::BusManager;
-#[cfg(feature = "socketcan")]
+#[cfg(all(feature = "socketcan", target_os = "linux"))]
 pub use common::open_socketcan;
 pub use lss_master::{LssError, LssMaster};
 pub use sdo_client::{RawAbortCode, SdoClient, SdoClientError};

--- a/zencan-common/Cargo.toml
+++ b/zencan-common/Cargo.toml
@@ -19,9 +19,11 @@ int-enum = "1.2.0"
 regex = { version = "1.11.1", optional = true }
 serde = { workspace = true, optional = true }
 snafu.workspace = true
-socketcan = { workspace = true, optional = true }
 tokio = { version = "1.47.1", features = ["net"], optional = true }
 toml = { workspace = true, optional = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+socketcan = { workspace = true, optional = true }
 
 [dev-dependencies]
 assertables = "9.8.0"

--- a/zencan-common/src/lib.rs
+++ b/zencan-common/src/lib.rs
@@ -25,11 +25,11 @@ pub mod sdo;
 mod time_types;
 pub mod traits;
 
-#[cfg(feature = "socketcan")]
+#[cfg(all(feature = "socketcan", target_os = "linux"))]
 mod socketcan;
 
-#[cfg(feature = "socketcan")]
-#[cfg_attr(docsrs, doc(cfg(feature = "socketcan")))]
+#[cfg(all(feature = "socketcan", target_os = "linux"))]
+#[cfg_attr(docsrs, doc(all(feature = "socketcan", target_os = "linux")))]
 pub use socketcan::open_socketcan;
 
 pub use messages::{CanError, CanId, CanMessage};

--- a/zencan-node/src/lib.rs
+++ b/zencan-node/src/lib.rs
@@ -212,8 +212,8 @@ pub use embedded_io;
 pub use zencan_common as common;
 
 pub use bootloader::{BootloaderInfo, BootloaderSection, BootloaderSectionCallbacks};
-#[cfg(feature = "socketcan")]
-#[cfg_attr(docsrs, doc(cfg(feature = "socketcan")))]
+#[cfg(all(feature = "socketcan", target_os = "linux"))]
+#[cfg_attr(docsrs, doc(all(feature = "socketcan", target_os = "linux")))]
 pub use common::open_socketcan;
 pub use node::{Callbacks, Node};
 pub use node_mbox::NodeMbox;


### PR DESCRIPTION
Hi, this PR enables zencan-client to compile on macOS and Windows.

Currently, the client is tied to SocketCAN, which restricts it to Linux. Since the existing abstraction is already quite clean, this PR only introduces minimal changes:

- add conditional dependencies in Cargo.toml to avoid requiring SocketCAN on non-Linux platforms
- slightly adjust the public API to make alternative CAN backends usable

This keeps the existing behavior on Linux unchanged, while allowing other platforms to use different CAN interfaces (e.g., USB-CAN).

Feedback is welcome!

![720px-USB-CAN-A-1](https://github.com/user-attachments/assets/2fdfdc15-23bf-4d21-8333-fd273ddaec43)
