### PR TITLE
Add scoped AI guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,21 @@ Cargo.lock
 # IDE project dirs
 .idea/
 
+# AI assistant local state and caches
+.claude/
+.codex/
+.continue/
+.cursor/
+.gemini/
+.kilocode/
+.opencode/
+.qwen/
+.roo/
+.windsurf/
+.aider.chat.history.md
+.aider.input.history
+.aider.tags.cache.v*
+CLAUDE.local.md
+
 # Syncthing files
 .stfolder

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,69 @@
+# AGENTS.md - zencan
+
+## Scope
+
+This file applies to the whole repository. More specific `AGENTS.md` files in
+subdirectories apply to their directories and supplement this guidance.
+
+## Project Structure
+
+- `zencan-node/`: CANopen node implementation for embedded `no_std` /
+  `no_alloc` use with statically allocated object storage.
+- `zencan-build/`: code generation from device config TOML into the static
+  object dictionary used by `zencan-node`.
+- `zencan-common/`: shared protocol, object, scalar, error, and CAN frame types.
+- `zencan-client/`: async client library for communicating with CANopen devices,
+  including Linux SocketCAN support.
+- `zencan-cli/`: `zencandump` and the interactive `zencan-cli` tools.
+- `zencan-macro/`: proc-macro crate re-exported by `zencan-node`.
+- `zencan-eds/`: EDS-related helper crate; currently `publish = false`.
+- `integration_tests/`: workspace-level integration tests across node, client,
+  and build behavior.
+- `examples/`: Linux SocketCAN, ESP32C3, and STM32G0 example nodes.
+- `.github/workflows/rust.yml`: source of truth for the current CI checks.
+
+## Tooling
+
+- Treat `rust-toolchain.toml`, the Cargo workspace, crate README files, example
+  README files, and `.github/workflows/rust.yml` as the repository truth
+  surfaces for toolchain, build, test, and documentation expectations.
+- The root workspace uses Rust edition 2021 and the pinned toolchain from
+  `rust-toolchain.toml`. Do not change the edition, MSRV, or toolchain without
+  an explicit compatibility reason.
+- Keep each crate's existing `std` / `no_std`, `log` / `defmt`, and `socketcan`
+  feature boundaries intact.
+
+## Protocol And API Expectations
+
+- CANopen wire behavior, object dictionary layout, PDO/SDO/NMT/SYNC semantics,
+  scalar encoding, and COB-ID handling are protocol contracts. Changes should
+  include focused tests and clear verification notes.
+- Prefer existing structured configuration, TOML parsing, object dictionary, and
+  code generation paths over ad hoc string manipulation.
+- Avoid using `.clone()`, `unwrap()`, or `expect()` as default fixes. Check the
+  ownership model, error boundary, and embedded resource constraints first.
+- Unsafe code should include a local `// SAFETY:` rationale and keep unsafe
+  blocks as small as practical.
+
+## Verification
+
+- Repository-wide Rust changes should align with CI where practical:
+  - `cargo build --examples --verbose`
+  - `cargo build` in `examples/esp-node`
+  - `cargo clippy -- -D warnings`
+  - `cargo clippy --examples -- -D warnings`
+  - `cargo fmt --check`
+  - `cargo test --verbose`
+  - `cargo build` in `examples/stm32g0-lilos-node`
+- For scoped changes, prefer the smallest command that covers the affected
+  crate or example, then report what was run.
+- Distinguish host tests, SocketCAN/vcan checks, embedded builds, flashing, and
+  real CAN hardware validation. Do not present one evidence layer as another.
+
+## Documentation
+
+- Update the relevant crate README or example README when user-visible API, CLI,
+  configuration format, protocol behavior, example workflow, or feature
+  boundaries change.
+- Do not commit build output, generated debug artifacts, `target/` contents, or
+  local editor/assistant state.

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md - examples
+
+## Scope
+
+Applies to all examples under `examples/`. More specific example directories can
+supplement this guidance with their own `AGENTS.md`.
+
+## Local Guidance
+
+- Examples are user-facing learning paths. Public workflow, CLI command, device
+  config, or wiring changes should update the matching example README.
+- Examples should demonstrate the recommended repository usage and avoid
+  bypassing the normal `zencan-build` / `zencan-node` generation and include
+  paths.
+- Do not commit build output, flash logs, temporary expanded/generated files, or
+  local hardware configuration.
+
+## Verification
+
+- For the Linux example, prefer `cargo build -p socketcan_node` or the workspace
+  examples build.
+- For embedded examples, prefer `cargo build` from the specific example
+  directory and state whether the change was only built or also run on hardware.

--- a/examples/esp-node/AGENTS.md
+++ b/examples/esp-node/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md - esp-node example
+
+## Scope
+
+Applies to `examples/esp-node/`, the ESP32C3 dummy CANopen node.
+
+## Local Guidance
+
+- This directory is its own Cargo workspace and is not a member of the root
+  workspace. Keep that boundary clear when changing dependencies, profiles,
+  target configuration, or build scripts.
+- The README documents `espflash`, USB-UART, CAN bitrate, and host CAN interface
+  steps. Treat build, flash, board-info, and CAN bus checks as separate
+  verification layers.
+- `zencan-node` is used with `default-features = false`. Avoid accidentally
+  introducing `std` or breaking the embedded path.
+
+## Verification
+
+- Prefer `cargo build` from this directory for code changes.
+- Only report flash or hardware validation when an ESP32C3 was actually used for
+  `cargo run` or `espflash board-info`.

--- a/examples/socketcan_node/AGENTS.md
+++ b/examples/socketcan_node/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md - socketcan_node example
+
+## Scope
+
+Applies to `examples/socketcan_node/`, the Linux SocketCAN example node.
+
+## Local Guidance
+
+- This is the primary example for node/client/CLI interoperability on Linux.
+  Bus wiring, node object config, PDO/SDO behavior, and logging changes should
+  be considered with `zencan-cli` documentation.
+- SocketCAN behavior depends on a Linux CAN interface. Distinguish compile
+  checks from `vcan0` or real CAN interface validation.
+- Keep the example clear and readable. Avoid mixing test-only fixture behavior
+  into the user-facing example.
+
+## Verification
+
+- Prefer `cargo build -p socketcan_node` for changes in this example.
+- When SocketCAN is available, a manual smoke with `vcan0` and
+  `zencandump` / `zencan-cli` is the relevant bus-level check.

--- a/examples/stm32g0-lilos-node/AGENTS.md
+++ b/examples/stm32g0-lilos-node/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md - stm32g0-lilos-node example
+
+## Scope
+
+Applies to `examples/stm32g0-lilos-node/`, the STM32G0B1 + lilos async runtime
+example node.
+
+## Local Guidance
+
+- This directory is its own Cargo workspace with its own `rust-toolchain.toml`
+  and edition 2024. Do not apply the root workspace toolchain or edition
+  assumptions here without checking the local files.
+- `defmt`, RTT, panic-probe, cortex-m runtime, FDCAN, and STM32 peripheral setup
+  are embedded target boundaries. Keep startup, interrupt, memory, and profile
+  changes explicit.
+- `zencan-node` is used with `default-features = false` and `defmt`. Avoid
+  introducing `std` or Linux-only dependencies.
+
+## Verification
+
+- Prefer `cargo build` from this directory for code changes.
+- Distinguish compile verification from probe, board, RTT, flash, or CAN bus
+  validation.

--- a/integration_tests/AGENTS.md
+++ b/integration_tests/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md - integration_tests
+
+## Scope
+
+Applies to `integration_tests/`, the workspace integration tests for combined
+node, client, and build behavior.
+
+## Local Guidance
+
+- These tests should cover cross-crate contracts. Keep pure single-crate unit
+  boundaries in the owning crate where possible.
+- Test names should describe protocol behavior clearly, such as PDO mapping,
+  SYNC-triggered transmission, SDO aborts, lifecycle behavior, or configuration
+  loading.
+- When adding several related regression cases, run the full relevant test
+  target if Cargo's name filtering would skip cases unintentionally.
+- Async tests, `serial_test`, and randomized data should remain reproducible and
+  avoid reliance on execution order or real CAN hardware.
+
+## Verification
+
+- Prefer `cargo test -p integration_tests` for changes in this directory.
+- For targeted regressions, also run the relevant test name when practical.

--- a/zencan-build/AGENTS.md
+++ b/zencan-build/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md - zencan-build crate
+
+## Scope
+
+Applies to `zencan-build/`, the library that generates object dictionary Rust
+code from device config TOML.
+
+## Local Guidance
+
+- Generated code is the compile-time contract consumed by `zencan-node`. Schema,
+  default value, object/subobject layout, PDO mapping, and access type changes
+  should be evaluated against node runtime behavior and documentation examples.
+- Prefer extending the existing parser, generated syntax tree, quote logic, and
+  test fixtures over hand-built Rust source strings.
+- Error messages should help locate the relevant config field, index/sub-index,
+  or type issue instead of only exposing lower-level `syn`, `prettyplease`, or
+  rustfmt errors.
+- The README debugging workflow can create temporary files such as `temp.rs`;
+  do not commit those artifacts.
+
+## Verification
+
+- Prefer `cargo test -p zencan-build` for crate changes.
+- For generated syntax or formatting changes, generate and compile output from
+  existing examples or tests. `cargo run -p zencan-build --example build_od -- <config>`
+  can be used to inspect generated code when diagnosing failures.

--- a/zencan-cli/AGENTS.md
+++ b/zencan-cli/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md - zencan-cli crate
+
+## Scope
+
+Applies to `zencan-cli/`, including `zencandump` and the interactive
+`zencan-cli` shell.
+
+## Local Guidance
+
+- CLI arguments, interactive commands, exit codes, stdout/stderr, shell parsing,
+  and completion behavior are user-visible.
+- Command semantics changes should update README examples and include tests for
+  parsing boundaries, error output, or interactive behavior where practical.
+- Process exit codes should indicate success or failure. Business counts should
+  be returned through stdout or structured output, not as successful exit codes.
+- SocketCAN and network interface operations can affect real systems. Clearly
+  distinguish parser/build tests from `vcan` or real interface checks.
+- Prefer clap, reedline, and shlex structured parsing facilities over fragile
+  hand-written parsers.
+
+## Verification
+
+- Prefer `cargo test -p zencan-cli` for crate changes.
+- For CLI compile or Linux-only dependency changes, also run
+  `cargo build -p zencan-cli`.
+- SocketCAN behavior changes should state whether `vcan0` or a real CAN
+  interface was used.

--- a/zencan-client/AGENTS.md
+++ b/zencan-client/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md - zencan-client crate
+
+## Scope
+
+Applies to `zencan-client/`, the async client library for communicating with
+CANopen devices.
+
+## Local Guidance
+
+- Client API shape, request/response correlation, timeout behavior, scanning,
+  SDO/PDO helpers, and node configuration loading are user-visible contracts.
+  Keep the README, CLI callers, and integration tests in sync with changes.
+- Keep async/Tokio boundaries clear. Linux SocketCAN assumptions should remain
+  scoped to Linux or socketcan feature paths.
+- Error handling should distinguish transport failures, timeouts, protocol
+  aborts, parse/config errors, and device responses.
+- Configuration TOML schema changes should be checked against
+  `zencan-cli load-config` behavior and example configuration files.
+
+## Verification
+
+- Prefer `cargo test -p zencan-client` for crate changes.
+- Bus, SocketCAN, or Linux-only transport changes should state whether SocketCAN
+  behavior was checked.
+- For behavior shared with the CLI, also run `cargo test -p zencan-cli` where
+  practical.

--- a/zencan-common/AGENTS.md
+++ b/zencan-common/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md - zencan-common crate
+
+## Scope
+
+Applies to `zencan-common/`, the shared protocol foundation used by node,
+client, build, and CLI crates.
+
+## Local Guidance
+
+- Types in this crate often propagate across the workspace. Changes to object,
+  CAN frame, SDO/PDO/NMT/SYNC, scalar, or error types should be checked against
+  `zencan-node`, `zencan-client`, `zencan-build`, and `integration_tests`.
+- Preserve `std`, `socketcan`, `log`, and `defmt` feature boundaries. Shared
+  types should not accidentally require Linux or Tokio.
+- CANopen encoding and decoding, endianness, bit width handling, 24-bit/64-bit
+  scalar support, and COB-ID handling are protocol contracts. Add focused tests
+  instead of relying only on indirect integration coverage.
+- Public re-exports affect downstream ergonomics. Public type moves, renames, or
+  error enum changes should be reflected in documentation and callers.
+
+## Verification
+
+- Prefer `cargo test -p zencan-common` for crate changes.
+- For feature boundary changes, also run
+  `cargo check -p zencan-common --no-default-features`.
+- SocketCAN-related changes should state whether the socketcan feature path was
+  checked.

--- a/zencan-eds/AGENTS.md
+++ b/zencan-eds/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md - zencan-eds crate
+
+## Scope
+
+Applies to `zencan-eds/`, the EDS-related helper crate. This crate is currently
+`publish = false`.
+
+## Local Guidance
+
+- EDS parsing and generation affect external tool interoperability. Section,
+  datatype, index/sub-index, and default value handling changes should preserve
+  traceable fixtures.
+- Do not describe experimental EDS behavior as a stable published API.
+- Logic shared with the object dictionary schema should either converge on
+  shared types or keep an explicitly documented boundary to avoid drift from
+  `zencan-build`.
+
+## Verification
+
+- Prefer `cargo test -p zencan-eds` for crate changes.
+- For input or output format changes, add or update fixtures covering round-trip
+  behavior or parser boundaries.

--- a/zencan-macro/AGENTS.md
+++ b/zencan-macro/AGENTS.md
@@ -1,0 +1,23 @@
+# AGENTS.md - zencan-macro crate
+
+## Scope
+
+Applies to `zencan-macro/`, the proc-macro crate re-exported by `zencan-node`.
+
+## Local Guidance
+
+- Macro output is downstream compile-time API. Input syntax, expansion shape,
+  and diagnostic changes should be evaluated with `zencan-node` documentation
+  and examples.
+- Prefer reusing types and generation logic from `zencan-build` and
+  `zencan-common` instead of copying protocol layout implementations.
+- Compile errors should point as closely as possible to the user input and name
+  the relevant field, object, or attribute issue.
+- cargo-expand can be useful for debugging, but expanded temporary files should
+  not be committed.
+
+## Verification
+
+- Prefer `cargo test -p zencan-macro` for crate changes.
+- If macro output affects examples, also run the relevant example build or
+  `cargo build --examples --verbose`.

--- a/zencan-node/AGENTS.md
+++ b/zencan-node/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md - zencan-node crate
+
+## Scope
+
+Applies to `zencan-node/`, the embedded-first CANopen node implementation.
+
+## Local Guidance
+
+- `no_std` / `no_alloc`, static object storage, and MCU use are core constraints
+  for this crate. Avoid introducing heap use, blocking OS assumptions, or
+  default `std` requirements without a clear compatibility reason.
+- Keep `std`, `log`, `defmt`, and `socketcan` feature boundaries clear. Default
+  feature convenience must not break the `default-features = false` embedded
+  path.
+- NMT state, the SDO server, PDO mapping and transmission, SYNC handling, object
+  access rights, and storage callbacks are protocol-sensitive paths. Cover
+  boundary conditions with focused tests.
+- Interface changes to the generated object dictionary must be evaluated with
+  `zencan-build/` and `zencan-macro/`.
+
+## Verification
+
+- Prefer `cargo test -p zencan-node` for crate changes.
+- For feature or `no_std` boundary changes, also run
+  `cargo check -p zencan-node --no-default-features`.
+- SocketCAN-related changes should cover `examples/socketcan_node/` or clearly
+  state that only non-SocketCAN checks were run.


### PR DESCRIPTION
## Summary

- Add upstream-facing AGENTS.md guidance at the repository root and in scoped crate, integration test, and example directories.
- Document project structure, crate-specific API/protocol boundaries, and the verification commands that cover each area.
- Add .gitignore entries for common AI assistant local state directories and cache files.

## Verification

- Ran git diff --check.
- Ran git diff --staged --check before the clean commit.
- Ran a simple staged diff secret scan; no matches.
- Scanned AGENTS.md files for local workflow terms such as macOS, devbox, fork, and user-specific response rules; no matches.
- Confirmed the branch contains one clean commit against origin/main.

## Notes

- Documentation/ignore-only change; Rust build/test commands were not run.
- No runtime behavior change.