### PR TITLE
[client] Remove upload_* and download_* accessors

### DIFF
--- a/integration_tests/tests/node_test.rs
+++ b/integration_tests/tests/node_test.rs
@@ -311,10 +311,10 @@ async fn test_store_and_restore_objects() {
             .download(0x2003, 0, "SAVEME".as_bytes())
             .await
             .unwrap();
-        client.download_u32(0x2000, 1, 900).await.unwrap();
+        client.write_u32(0x2000, 1, 900).await.unwrap();
 
         // Trigger a save
-        client.download_u32(0x1010, 1, SAVE_CMD).await.unwrap();
+        client.write_u32(0x1010, 1, SAVE_CMD).await.unwrap();
 
         ctx.wait_for_process(1).await;
 
@@ -329,7 +329,7 @@ async fn test_store_and_restore_objects() {
             .download(0x2003, 0, "NOTSAVED".as_bytes())
             .await
             .unwrap();
-        client.download_u32(0x2000, 1, 500).await.unwrap();
+        client.write_u32(0x2000, 1, 500).await.unwrap();
 
         zencan_node::restore_stored_objects(&OD_TABLE, &serialized_data.read().unwrap());
 
@@ -341,7 +341,7 @@ async fn test_store_and_restore_objects() {
             "NOTSAVED".as_bytes()
         );
         // Should have saved
-        assert_eq!(client.upload_u32(0x2000, 1).await.unwrap(), 900);
+        assert_eq!(client.read_u32(0x2000, 1).await.unwrap(), 900);
     };
 
     test_with_background_process(&mut [&mut node], &mut bus, test_task).await;
@@ -370,7 +370,7 @@ async fn test_empty_string_read() {
     let _logger = BusLogger::new(bus.new_receiver());
 
     let test_task = move |_ctx| async move {
-        let empty_string = client.upload_utf8(0x3005, 0).await.unwrap();
+        let empty_string = client.read_utf8(0x3005, 0).await.unwrap();
         assert_eq!("", empty_string);
     };
     test_with_background_process(&mut [&mut node], &mut bus, test_task).await;

--- a/integration_tests/tests/pdo_tests.rs
+++ b/integration_tests/tests/pdo_tests.rs
@@ -45,39 +45,39 @@ async fn test_rpdo_assignment() {
 
     let test_task = move |mut ctx: TestContext| async move {
         // Readback the largest sub index
-        assert_eq!(2, client.upload_u8(0x1400, 0).await.unwrap());
+        assert_eq!(2, client.read_u8(0x1400, 0).await.unwrap());
 
         // Check initial value of RPDO1 cob_id
-        assert_eq!(0x300, client.upload_u32(0x1400, 1).await.unwrap());
+        assert_eq!(0x300, client.read_u32(0x1400, 1).await.unwrap());
 
         // Set COB-ID and readback
         // Invalid bit cleared, and ID == 0x201.
         let cob_id_word: u32 = 0x201;
-        client.download_u32(0x1400, 1, cob_id_word).await.unwrap();
+        client.write_u32(0x1400, 1, cob_id_word).await.unwrap();
 
-        let readback_cob_id_word = client.upload_u32(0x1400, 1).await.unwrap();
+        let readback_cob_id_word = client.read_u32(0x1400, 1).await.unwrap();
         assert_eq!(cob_id_word, readback_cob_id_word);
 
         // Check initial values of RPDO0 mappings
         // These are set to 0x2000sub2 and 0x300Csub12 by default in example1.toml
-        assert_eq!(2, client.upload_u8(0x1600, 0).await.unwrap());
+        assert_eq!(2, client.read_u8(0x1600, 0).await.unwrap());
         let default_mapping_entry_1: u32 = (0x2000 << 16) | (2 << 8) | 32;
         let default_mapping_entry_2: u32 = (0x300C << 16) | (12 << 8) | 24;
         assert_eq!(
             default_mapping_entry_1,
-            client.upload_u32(0x1600, 1).await.unwrap()
+            client.read_u32(0x1600, 1).await.unwrap()
         );
         assert_eq!(
             default_mapping_entry_2,
-            client.upload_u32(0x1600, 2).await.unwrap()
+            client.read_u32(0x1600, 2).await.unwrap()
         );
-        assert_eq!(u24::new(0), client.upload_u24(0x300C, 12).await.unwrap());
+        assert_eq!(u24::new(0), client.read_u24(0x300C, 12).await.unwrap());
 
         // Modify RPDO0 to map to object 0x2000, subindex 1, length 32 bits
         let mapping_entry: u32 = (0x2000 << 16) | (1 << 8) | 32;
-        client.download_u32(0x1600, 1, mapping_entry).await.unwrap();
+        client.write_u32(0x1600, 1, mapping_entry).await.unwrap();
         // // Set the number of valid mappings
-        client.download_u8(0x1600, 0, 2).await.unwrap();
+        client.write_u8(0x1600, 0, 2).await.unwrap();
 
         // Put in operational mode
         nmt.nmt_start(0).await.unwrap();
@@ -96,10 +96,10 @@ async fn test_rpdo_assignment() {
         // Delay a bit, because node process() method has to be called for PDO to apply
         ctx.wait_for_process(1).await;
         // Readback the mapped object; the PDO message above should have updated it
-        assert_eq!(500, client.upload_u32(0x2000, 1).await.unwrap());
+        assert_eq!(500, client.read_u32(0x2000, 1).await.unwrap());
         assert_eq!(
             u24::new(0x010203),
-            client.upload_u24(0x300C, 12).await.unwrap()
+            client.read_u24(0x300C, 12).await.unwrap()
         );
     };
 
@@ -151,20 +151,20 @@ async fn test_tpdo_assignment() {
             .await
             .unwrap();
 
-        client.download_u32(0x2001, 1, 333).await.unwrap();
+        client.write_u32(0x2001, 1, 333).await.unwrap();
         client
-            .download_i24(0x300C, 11, i24::new(-65432))
+            .write_i24(0x300C, 11, i24::new(-65432))
             .await
             .unwrap();
 
         // Set the TPDO mapping to 0x2001, subindex 1, length 32 bits
         let mapping_entry: u32 = (0x2001 << 16) | (1 << 8) | 32;
-        client.download_u32(0x1A00, 1, mapping_entry).await.unwrap();
+        client.write_u32(0x1A00, 1, mapping_entry).await.unwrap();
         // Set the second TPDO mapping entry to 0x300C, subindex 11, length 24 bits
         let mapping_entry: u32 = (0x300C << 16) | (11 << 8) | 24;
-        client.download_u32(0x1A00, 2, mapping_entry).await.unwrap();
+        client.write_u32(0x1A00, 2, mapping_entry).await.unwrap();
         // Set the number of valid mappings
-        client.download_u8(0x1A00, 0, 2).await.unwrap();
+        client.write_u8(0x1A00, 0, 2).await.unwrap();
 
         // Node has to be in Operating mode to send PDOs
         nmt.nmt_start(0).await.unwrap();
@@ -287,9 +287,9 @@ async fn test_tpdo_event_flags() {
             .unwrap();
 
         // Set some known values into the mapped application objects
-        client.download_u32(0x2000, 1, 222).await.unwrap();
-        client.download_u32(0x2001, 1, 333).await.unwrap();
-        client.download_u32(0x3000, 0, 444).await.unwrap();
+        client.write_u32(0x2000, 1, 222).await.unwrap();
+        client.write_u32(0x2001, 1, 333).await.unwrap();
+        client.write_u32(0x3000, 0, 444).await.unwrap();
 
         // Node has to be in Operating mode to send PDOs
         nmt.nmt_start(0).await.unwrap();
@@ -450,9 +450,9 @@ async fn test_tpdo_sync_initiated_transmission() {
             .unwrap();
 
         // Set some known values into the mapped application objects
-        client.download_u32(0x2000, 1, 222).await.unwrap();
-        client.download_u32(0x2001, 1, 333).await.unwrap();
-        client.download_u32(0x3000, 0, 444).await.unwrap();
+        client.write_u32(0x2000, 1, 222).await.unwrap();
+        client.write_u32(0x2001, 1, 333).await.unwrap();
+        client.write_u32(0x3000, 0, 444).await.unwrap();
 
         // Node has to be in Operating mode to send PDOs
         nmt.nmt_start(0).await.unwrap();
@@ -612,17 +612,17 @@ async fn test_pdo_configuration() {
         client.configure_tpdo(0, &config).await?;
 
         // Check that the expected objects got the expected values
-        assert_eq!(2, client.upload_u8(0x1A00, 0).await?);
+        assert_eq!(2, client.read_u8(0x1A00, 0).await?);
         assert_eq!(
             (0x2000 << 16) | 1 << 8 | 32,
-            client.upload_u32(0x1A00, 1).await?
+            client.read_u32(0x1A00, 1).await?
         );
         assert_eq!(
             (0x2001 << 16) | 1 << 8 | 32,
-            client.upload_u32(0x1A00, 2).await?
+            client.read_u32(0x1A00, 2).await?
         );
-        assert_eq!(254, client.upload_u8(0x1800, 2).await?);
-        assert_eq!(0x301, client.upload_u32(0x1800, 1).await?);
+        assert_eq!(254, client.read_u8(0x1800, 2).await?);
+        assert_eq!(0x301, client.read_u32(0x1800, 1).await?);
 
         Ok::<_, Box<dyn std::error::Error>>(())
     };

--- a/zencan-client/src/sdo_client.rs
+++ b/zencan-client/src/sdo_client.rs
@@ -135,14 +135,8 @@ macro_rules! access_methods {
     ($type: ty) => {
 
         paste! {
-            #[doc = concat!("Read a ", stringify!($type), " sub object from the SDO server\n\n")]
-            #[doc = concat!("This is an alias for upload_", stringify!($type), " for a more intuitive API")]
-            pub async fn [<read_ $type>](&mut self, index: u16, sub: u8) -> Result<$type> {
-                self.[<upload_ $type>](index, sub).await
-            }
-
             #[doc = concat!("Read a ", stringify!($type), " sub object from the SDO server")]
-            pub async fn [<upload_ $type>](&mut self, index: u16, sub: u8) -> Result<$type> {
+            pub async fn [<read_ $type>](&mut self, index: u16, sub: u8) -> Result<$type> {
                 let data = self.upload(index, sub).await?;
                 if data.len() != <$type as ReadSize>::READ_SIZE {
                     return UnexpectedSizeSnafu.fail();
@@ -150,14 +144,8 @@ macro_rules! access_methods {
                 Ok($type::from_le_bytes(data.try_into().unwrap()))
             }
 
-            #[doc = concat!("Write a ", stringify!($type), " sub object on the SDO server\n\n")]
-            #[doc = concat!("This is an alias for download_", stringify!($type), " for a more intuitive API")]
+            #[doc = concat!("Write a ", stringify!($type), " sub object from the SDO server")]
             pub async fn [<write_ $type>](&mut self, index: u16, sub: u8, value: $type) -> Result<()> {
-                self.[<download_ $type>](index, sub, value).await
-            }
-
-            #[doc = concat!("Read a ", stringify!($type), " sub object from the SDO server")]
-            pub async fn [<download_ $type>](&mut self, index: u16, sub: u8, value: $type) -> Result<()> {
                 let data = value.to_le_bytes();
                 self.download(index, sub, &data).await
             }
@@ -570,38 +558,12 @@ impl<S: AsyncCanSender, R: AsyncCanReceiver> SdoClient<S, R> {
     access_methods!(i8);
 
     /// Write to a TimeOfDay object on the SDO server
-    pub async fn download_time_of_day(
-        &mut self,
-        index: u16,
-        sub: u8,
-        data: TimeOfDay,
-    ) -> Result<()> {
-        let data = data.to_le_bytes();
-        self.download(index, sub, &data).await
-    }
-
-    /// Write to a TimeOfDay object on the SDO server
-    ///
-    /// Alias for `download_time_of_day`. This is a convenience function to allow for a more intuitive API.
     pub async fn write_time_of_day(&mut self, index: u16, sub: u8, data: TimeOfDay) -> Result<()> {
         let data = data.to_le_bytes();
         self.download(index, sub, &data).await
     }
 
     /// Write to a TimeDifference object on the SDO server
-    pub async fn download_time_difference(
-        &mut self,
-        index: u16,
-        sub: u8,
-        data: TimeDifference,
-    ) -> Result<()> {
-        let data = data.to_le_bytes();
-        self.download(index, sub, &data).await
-    }
-
-    /// Write to a TimeDifference object on the SDO server
-    ///
-    /// Alias for `download_time_difference`. This is a convenience function to allow for a more intuitive API.
     pub async fn write_time_difference(
         &mut self,
         index: u16,
@@ -613,17 +575,13 @@ impl<S: AsyncCanSender, R: AsyncCanReceiver> SdoClient<S, R> {
     }
 
     /// Read a string from the SDO server
-    pub async fn upload_utf8(&mut self, index: u16, sub: u8) -> Result<String> {
+    pub async fn read_utf8(&mut self, index: u16, sub: u8) -> Result<String> {
         let data = self.upload(index, sub).await?;
         Ok(String::from_utf8_lossy(&data).into())
     }
-    /// Alias for `upload_utf8`
-    pub async fn read_utf8(&mut self, index: u16, sub: u8) -> Result<String> {
-        self.upload_utf8(index, sub).await
-    }
 
     /// Read a TimeOfDay object from the SDO server
-    pub async fn upload_time_of_day(&mut self, index: u16, sub: u8) -> Result<TimeOfDay> {
+    pub async fn read_time_of_day(&mut self, index: u16, sub: u8) -> Result<TimeOfDay> {
         let data = self.upload(index, sub).await?;
         if data.len() != TimeOfDay::SIZE {
             UnexpectedSizeSnafu.fail()
@@ -633,29 +591,13 @@ impl<S: AsyncCanSender, R: AsyncCanReceiver> SdoClient<S, R> {
     }
 
     /// Read a TimeOfDay object from the SDO server
-    ///
-    /// Alias for `upload_time_of_day`. This is a convenience function to allow for a more intuitive
-    /// API.
-    pub async fn read_time_of_day(&mut self, index: u16, sub: u8) -> Result<TimeOfDay> {
-        self.upload_time_of_day(index, sub).await
-    }
-
-    /// Read a TimeOfDay object from the SDO server
-    pub async fn upload_time_difference(&mut self, index: u16, sub: u8) -> Result<TimeDifference> {
+    pub async fn read_time_difference(&mut self, index: u16, sub: u8) -> Result<TimeDifference> {
         let data = self.upload(index, sub).await?;
         if data.len() != TimeDifference::SIZE {
             UnexpectedSizeSnafu.fail()
         } else {
             Ok(TimeDifference::from_le_bytes(data.try_into().unwrap()))
         }
-    }
-
-    /// Read a TimeOfDay object from the SDO server
-    ///
-    /// Alias for `upload_time_of_day`. This is a convenience function to allow for a more intuitive
-    /// API.
-    pub async fn read_time_difference(&mut self, index: u16, sub: u8) -> Result<TimeDifference> {
-        self.upload_time_difference(index, sub).await
     }
 
     /// Read an object as a visible string
@@ -670,10 +612,10 @@ impl<S: AsyncCanSender, R: AsyncCanReceiver> SdoClient<S, R> {
     ///
     /// All nodes should implement this object
     pub async fn read_identity(&mut self) -> Result<LssIdentity> {
-        let vendor_id = self.upload_u32(object_ids::IDENTITY, 1).await?;
-        let product_code = self.upload_u32(object_ids::IDENTITY, 2).await?;
-        let revision_number = self.upload_u32(object_ids::IDENTITY, 3).await?;
-        let serial = self.upload_u32(object_ids::IDENTITY, 4).await?;
+        let vendor_id = self.read_u32(object_ids::IDENTITY, 1).await?;
+        let product_code = self.read_u32(object_ids::IDENTITY, 2).await?;
+        let revision_number = self.read_u32(object_ids::IDENTITY, 3).await?;
+        let serial = self.read_u32(object_ids::IDENTITY, 4).await?;
         Ok(LssIdentity::new(
             vendor_id,
             product_code,
@@ -684,8 +626,7 @@ impl<S: AsyncCanSender, R: AsyncCanReceiver> SdoClient<S, R> {
 
     /// Write object 0x1010sub1 to command all objects be saved
     pub async fn save_objects(&mut self) -> Result<()> {
-        self.download_u32(object_ids::SAVE_OBJECTS, 1, SAVE_CMD)
-            .await
+        self.write_u32(object_ids::SAVE_OBJECTS, 1, SAVE_CMD).await
     }
 
     /// Read the device name object


### PR DESCRIPTION
I don't see any reason to maintain both function names; there are a lot of them and so its a lot of noise.  I think read and write are clearer names than upload/download.