### PR TITLE
[node] Fix boolean object error 

### DIFF
--- a/integration_tests/device_configs/example1.toml
+++ b/integration_tests/device_configs/example1.toml
@@ -245,6 +245,13 @@ access_type = "rw"
 pdo_mapping = "both"
 
 [[objects]]
+index = 0x300D
+parameter_name = "Boolean var"
+object_type = "var"
+data_type = "boolean"
+access_type = "rw"
+
+[[objects]]
 index = 0x3010
 parameter_name = "Application Callback Var"
 object_type = "var"

--- a/integration_tests/tests/node_test.rs
+++ b/integration_tests/tests/node_test.rs
@@ -500,6 +500,37 @@ async fn test_time_field_access() {
     test_with_background_process(&mut [&mut node], &mut bus, test_task).await;
 }
 
+#[serial]
+#[tokio::test]
+async fn test_boolean_object_access() {
+    use object_dict1::*;
+
+    let _ = env_logger::try_init();
+
+    const NODE_ID: u8 = 1;
+    let mut bus = SimBus::new();
+    bus.add_node(&NODE_MBOX);
+    let callbacks = Callbacks::new();
+    let mut node = Node::new(
+        NodeId::new(NODE_ID).unwrap(),
+        callbacks,
+        &NODE_MBOX,
+        &NODE_STATE,
+        &OD_TABLE,
+    );
+    let mut client = get_sdo_client(&mut bus, NODE_ID);
+
+    let _logger = BusLogger::new(bus.new_receiver());
+
+    let test_task = move |_ctx| async move {
+        client.write_bool(0x300D, 0, true).await.unwrap();
+        assert_eq!(true, OBJECT300D.get_value());
+        client.write_bool(0x300D, 0, false).await.unwrap();
+        assert_eq!(false, OBJECT300D.get_value());
+    };
+    test_with_background_process(&mut [&mut node], &mut bus, test_task).await;
+}
+
 /// Test that the Node properly calls the sync callback when the sync object is received
 #[serial]
 #[tokio::test]

--- a/integration_tests/tests/pdo_tests.rs
+++ b/integration_tests/tests/pdo_tests.rs
@@ -175,13 +175,13 @@ async fn test_tpdo_assignment() {
         sender.send(sync_msg).await.unwrap();
 
         // We expect to receive the sync message just sent first
-        let rx_sync_msg = timeout(Duration::from_millis(50), rx.recv())
+        let rx_sync_msg = timeout(Duration::from_millis(200), rx.recv())
             .await
             .expect("Expected SYNC message, no CAN message received")
             .expect("recv returned an error");
         assert_eq!(sync_msg.id, rx_sync_msg.id);
         // Then expect a PDO message
-        let msg = timeout(Duration::from_millis(50), rx.recv())
+        let msg = timeout(Duration::from_millis(200), rx.recv())
             .await
             .expect("Expected PDO, no CAN message received")
             .expect("recv returned an error");

--- a/zencan-build/src/codegen.rs
+++ b/zencan-build/src/codegen.rs
@@ -316,9 +316,9 @@ fn get_default_tokens(
             match data_type {
                 DCDataType::Boolean => {
                     if *i != 0 {
-                        Ok(quote!(ScalarField<bool>::new(true)))
+                        Ok(quote!(ScalarField::<bool>::new(true)))
                     } else {
-                        Ok(quote!(ScalarField<bool>::new(false)))
+                        Ok(quote!(ScalarField::<bool>::new(false)))
                     }
                 }
                 DCDataType::Int8 => Ok(quote!(ScalarField::<i8>::new(#i as i8))),

--- a/zencan-client/src/sdo_client.rs
+++ b/zencan-client/src/sdo_client.rs
@@ -608,6 +608,21 @@ impl<S: AsyncCanSender, R: AsyncCanReceiver> SdoClient<S, R> {
         Ok(String::from_utf8_lossy(&bytes).into())
     }
 
+    /// Read an object as a boolean
+    pub async fn read_bool(&mut self, index: u16, sub: u8) -> Result<bool> {
+        let bytes = self.upload(index, sub).await?;
+        if bytes.len() != 1 {
+            return UnexpectedSizeSnafu.fail();
+        }
+        Ok(bytes[0] != 0)
+    }
+
+    /// Write an object as a boolean
+    pub async fn write_bool(&mut self, index: u16, sub: u8, value: bool) -> Result<()> {
+        let data = if value { [1u8] } else { [0u8] };
+        self.download(index, sub, &data).await
+    }
+
     /// Read the identity object
     ///
     /// All nodes should implement this object

--- a/zencan-node/src/object_dict/sub_objects.rs
+++ b/zencan-node/src/object_dict/sub_objects.rs
@@ -184,6 +184,15 @@ impl_scalar_field!(i64);
 impl_scalar_field!(f32);
 impl_scalar_field!(f64);
 
+impl ScalarField<bool> {
+    /// Create a new field
+    pub const fn new(value: bool) -> Self {
+        Self {
+            value: AtomicCell::new(value),
+        }
+    }
+}
+
 // bool doesn't support from_le_bytes so it needs a special implementation
 impl SubObjectAccess for ScalarField<bool> {
     fn read(&self, offset: usize, buf: &mut [u8]) -> Result<usize, AbortCode> {


### PR DESCRIPTION
- Fix error in generated code when using boolean objects (fixes #73) 
- add boolean object access to integration tests
- Add read_bool/write_bool to SdoClient