### PR TITLE
Transmit PDO messages with shorter DLC

### DIFF
--- a/integration_tests/tests/pdo_tests.rs
+++ b/integration_tests/tests/pdo_tests.rs
@@ -187,6 +187,8 @@ async fn test_tpdo_assignment() {
             .expect("recv returned an error");
 
         assert_eq!(CanId::std(0x181), msg.id);
+        assert_eq!(7, msg.dlc);
+        assert_eq!(7, msg.data().len());
         let field1 = u32::from_le_bytes(msg.data[0..4].try_into().unwrap());
         let field2 = i24::from_le_bytes(msg.data[4..7].try_into().unwrap());
         assert_eq!(333, field1);
@@ -478,6 +480,7 @@ async fn test_tpdo_sync_initiated_transmission() {
         let msg = rx.try_recv().expect("No message received after TPDO event");
         println!("received after sync {sync_counter}: {msg:#x?}");
         assert_eq!(CanId::std(0x181), msg.id);
+        assert_eq!(8, msg.data().len());
         assert_eq!(
             222,
             u32::from_le_bytes(msg.data()[0..4].try_into().unwrap())
@@ -495,13 +498,10 @@ async fn test_tpdo_sync_initiated_transmission() {
         let msg = rx.try_recv().expect("No message received after TPDO event");
         println!("received after sync {sync_counter}: {msg:#x?}");
         assert_eq!(CanId::std(0x182), msg.id);
+        assert_eq!(4, msg.data().len());
         assert_eq!(
             444,
             u32::from_le_bytes(msg.data()[0..4].try_into().unwrap())
-        );
-        assert_eq!(
-            000,
-            u32::from_le_bytes(msg.data()[4..8].try_into().unwrap())
         );
         // should only have gotten one message
         assert!(rx.try_recv().is_none());
@@ -547,13 +547,10 @@ async fn test_tpdo_sync_initiated_transmission() {
         let msg = rx.try_recv().expect("No message received after TPDO event");
         println!("received after sync {sync_counter}: {msg:#x?}");
         assert_eq!(CanId::std(0x182), msg.id);
+        assert_eq!(4, msg.data().len());
         assert_eq!(
             444,
             u32::from_le_bytes(msg.data()[0..4].try_into().unwrap())
-        );
-        assert_eq!(
-            000,
-            u32::from_le_bytes(msg.data()[4..8].try_into().unwrap())
         );
 
         // Nothing else in queue yet

--- a/zencan-node/Cargo.toml
+++ b/zencan-node/Cargo.toml
@@ -26,6 +26,7 @@ futures.workspace = true
 log = { version = "0.4", optional = true }
 static_cell = "2.1.1"
 portable-atomic = "1.11.1"
+heapless = "0.9.1"
 
 [features]
 default = ["log", "std"]

--- a/zencan-node/src/node_mbox.rs
+++ b/zencan-node/src/node_mbox.rs
@@ -166,8 +166,8 @@ impl NodeMbox {
                 continue;
             }
             if id == rpdo.cob_id() {
-                let mut data = [0u8; 8];
-                data[0..msg.data().len()].copy_from_slice(msg.data());
+                // Unwrap safety: msg data cannot be longer than 8 byte size of the Vec
+                let data = heapless::Vec::from_slice(msg.data()).unwrap();
                 rpdo.buffered_value.store(Some(data));
                 return Ok(());
             }

--- a/zencan-node/src/pdo.rs
+++ b/zencan-node/src/pdo.rs
@@ -192,7 +192,7 @@ pub struct Pdo<'a> {
     /// Tracks the number of sync signals since this was last sent or received
     sync_counter: AtomicCell<u8>,
     /// The last received data value for an RPDO, or ready to transmit data for a TPDO
-    pub buffered_value: AtomicCell<Option<[u8; 8]>>,
+    pub buffered_value: AtomicCell<Option<heapless::Vec<u8, 8>>>,
     /// Indicates how many of the values in mapping_params are valid
     ///
     /// This represents sub0 for the mapping object
@@ -402,6 +402,7 @@ impl<'a> Pdo<'a> {
             }
             // validity of the mappings must be validated during write, so that error here is not
             // possible
+
             param
                 .object
                 .data
@@ -411,7 +412,9 @@ impl<'a> Pdo<'a> {
         }
         // If there is an old value here which has not been sent yet, replace it with the latest
         // Data will be sent by mbox in message handling thread.
-        self.buffered_value.store(Some(data));
+        // Unwrap safety: ensured above that data cannot be longer than 8 bytes
+        self.buffered_value
+            .store(Some(heapless::Vec::from_slice(&data[0..offset]).unwrap()));
     }
 
     /// Lookup a PDO mapped object and create a MappingEntry if it is valid


### PR DESCRIPTION
Transmit PDO messages were being sent with 8 bytes even when the size of PDO mapped objects was less than 8 bytes. This change sends only the min required message size based on the PDO mapping. Fixes #67.