### PR TITLE
Fix/mitigate intermittent test failures

### DIFF
--- a/integration_tests/tests/lss_test.rs
+++ b/integration_tests/tests/lss_test.rs
@@ -42,7 +42,7 @@ async fn test_fast_scan() {
 
     let _logger = BusLogger::new(bus.new_receiver());
 
-    const TIMEOUT: Duration = Duration::from_millis(5);
+    const TIMEOUT: Duration = Duration::from_millis(25);
     let mut lss_master = LssMaster::new(bus.new_sender(), bus.new_receiver());
 
     test_with_background_process(

--- a/integration_tests/tests/pdo_tests.rs
+++ b/integration_tests/tests/pdo_tests.rs
@@ -135,7 +135,7 @@ async fn test_tpdo_assignment() {
     let mut nmt = NmtMaster::new(bus.new_sender(), bus.new_receiver());
 
     let mut sender = bus.new_sender();
-    let test_task = move |_ctx| async move {
+    let test_task = move |mut ctx: TestContext| async move {
         // Set the TPDO COB ID
         client
             .download(TPDO_COMM1_ID, PDO_COMM_COB_SUBID, &0x181u32.to_le_bytes())
@@ -175,13 +175,14 @@ async fn test_tpdo_assignment() {
         sender.send(sync_msg).await.unwrap();
 
         // We expect to receive the sync message just sent first
-        let rx_sync_msg = timeout(Duration::from_millis(200), rx.recv())
+        let rx_sync_msg = timeout(Duration::from_millis(1), rx.recv())
             .await
             .expect("Expected SYNC message, no CAN message received")
             .expect("recv returned an error");
         assert_eq!(sync_msg.id, rx_sync_msg.id);
+        ctx.wait_for_process(1).await;
         // Then expect a PDO message
-        let msg = timeout(Duration::from_millis(200), rx.recv())
+        let msg = timeout(Duration::from_millis(1), rx.recv())
             .await
             .expect("Expected PDO, no CAN message received")
             .expect("recv returned an error");


### PR DESCRIPTION
These two tests have been failing occasionally due to timeouts when certain tokio tasks were not executed quickly enough. 

The PDO test should never fail now, because it can use the TestContext to wait for a process call to occur before expecting
messages. 

The LSS test is just a timeout increase to make failures less likely. 