### PR TITLE
expose SocketCan{Sender,Receiver}

### DIFF
--- a/zencan-common/src/lib.rs
+++ b/zencan-common/src/lib.rs
@@ -30,7 +30,7 @@ mod socketcan;
 
 #[cfg(all(feature = "socketcan", target_os = "linux"))]
 #[cfg_attr(docsrs, doc(all(feature = "socketcan", target_os = "linux")))]
-pub use socketcan::open_socketcan;
+pub use socketcan::{open_socketcan, SocketCanReceiver, SocketCanSender};
 
 pub use arbitrary_int::{i24, u24};
 pub use messages::{CanError, CanId, CanMessage};

--- a/zencan-common/src/socketcan.rs
+++ b/zencan-common/src/socketcan.rs
@@ -42,6 +42,7 @@ fn zencan_message_to_socket_frame(frame: CanMessage) -> socketcan::CanFrame {
     }
 }
 
+/// A handle to a socketcan CAN socket implementing AsyncCanReceiver.
 #[derive(Debug, Clone)]
 pub struct SocketCanReceiver {
     socket: Arc<AsyncCanSocket>,
@@ -138,6 +139,7 @@ impl AsyncCanReceiver for SocketCanReceiver {
     }
 }
 
+/// A handle to a socketcan CAN socket implementing AsyncCanSender.
 #[derive(Debug, Clone)]
 pub struct SocketCanSender {
     socket: Arc<AsyncCanSocket>,


### PR DESCRIPTION
Exposing these types makes is easier to create a socketcan BusManager without having to use generics, because the call site gets full type information from `open_socketcan()`.