### PR TITLE
Allow dlc greater than 8.

### DIFF
--- a/zencan-common/src/messages.rs
+++ b/zencan-common/src/messages.rs
@@ -56,7 +56,8 @@ impl CanId {
     }
 }
 
-const MAX_DATA_LENGTH: usize = 8;
+/// Maximum number of bytes of data, for classic CAN this is 8 and for CAN FD this is 64
+pub const MAX_DATA_LENGTH: usize = 64;
 
 /// A struct to contain a CanMessage
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -87,7 +88,17 @@ impl Default for CanMessage {
 impl CanMessage {
     /// Create a new CAN message
     pub fn new(id: CanId, data: &[u8]) -> Self {
-        let dlc = data.len() as u8;
+        let len = data.len() as u8;
+        let dlc = match len {
+            0..=8 => len,
+            9..=12 => 12,
+            13..=16 => 16,
+            17..=20 => 20,
+            21..=24 => 24,
+            25..=32 => 32,
+            33..=48 => 48,
+            _ => MAX_DATA_LENGTH as u8,
+        };
         if dlc > MAX_DATA_LENGTH as u8 {
             panic!(
                 "Data length exceeds maximum size of {} bytes",
@@ -95,7 +106,7 @@ impl CanMessage {
             );
         }
         let mut buf = [0u8; MAX_DATA_LENGTH];
-        buf[0..dlc as usize].copy_from_slice(data);
+        buf[0..len as usize].copy_from_slice(data);
         let rtr = false;
 
         Self {

--- a/zencan-common/src/sdo.rs
+++ b/zencan-common/src/sdo.rs
@@ -171,12 +171,7 @@ impl BlockSegment {
 
     /// Create a CanMessage from the BlockSegment for transmission
     pub fn to_can_message(&self, id: CanId) -> CanMessage {
-        CanMessage {
-            data: self.to_bytes(),
-            dlc: 8,
-            rtr: false,
-            id,
-        }
+        CanMessage::new(id, &self.to_bytes())
     }
 }
 
@@ -889,7 +884,9 @@ impl TryFrom<[u8; 8]> for SdoResponse {
 impl TryFrom<CanMessage> for SdoResponse {
     type Error = ();
     fn try_from(msg: CanMessage) -> Result<Self, Self::Error> {
-        msg.data.try_into()
+        let mut msg_data = [0u8; 8];
+        msg_data[0..8].copy_from_slice(&msg.data[0..8]);
+        msg_data.try_into()
     }
 }
 impl SdoResponse {

--- a/zencan-node/src/node.rs
+++ b/zencan-node/src/node.rs
@@ -364,7 +364,7 @@ impl<'a> Node<'a> {
                     continue;
                 }
                 if let Some(new_data) = rpdo.buffered_value.take() {
-                    rpdo.store_pdo_data(&new_data);
+                    rpdo.store_pdo_data(&new_data.data);
                     update_flag = true;
                 }
             }

--- a/zencan-node/src/node_mbox.rs
+++ b/zencan-node/src/node_mbox.rs
@@ -169,9 +169,8 @@ impl NodeMbox {
                 continue;
             }
             if id == rpdo.cob_id() {
-                // Unwrap safety: msg data cannot be longer than 8 byte size of the Vec
-                let data = heapless::Vec::from_slice(msg.data()).unwrap();
-                rpdo.buffered_value.store(Some(data));
+                rpdo.buffered_value
+                    .store(Some(CanMessage::new(rpdo.cob_id(), msg.data())));
                 return Ok(());
             }
         }
@@ -197,8 +196,8 @@ impl NodeMbox {
     /// - SDO server responses    
     pub fn next_transmit_message(&self) -> Option<CanMessage> {
         for pdo in self.tx_pdos.iter() {
-            if let Some(buf) = pdo.buffered_value.take() {
-                return Some(CanMessage::new(pdo.cob_id(), &buf));
+            if let Some(msg) = pdo.buffered_value.take() {
+                return Some(msg);
             }
         }
 

--- a/zencan-node/src/pdo.rs
+++ b/zencan-node/src/pdo.rs
@@ -47,18 +47,19 @@ use crate::{
     },
 };
 use zencan_common::{
+    messages::MAX_DATA_LENGTH,
     nmt::NmtState,
     objects::{AccessType, DataType, ObjectCode, PdoMappable, SubInfo},
     pdo::PdoMapping,
     sdo::AbortCode,
-    AtomicCell, CanId, NodeId,
+    AtomicCell, CanId, CanMessage, NodeId,
 };
 
 /// Specifies the number of mapping parameters supported per PDO
 ///
 /// Since we do not yet support CAN-FD, or sub-byte mapping, it's not possible to map more than 8
 /// objects to a single PDO
-const N_MAPPING_PARAMS: usize = 8;
+const N_MAPPING_PARAMS: usize = MAX_DATA_LENGTH;
 
 #[derive(Clone, Copy)]
 /// Data structure for storing a PDO object mapping
@@ -192,7 +193,7 @@ pub struct Pdo<'a> {
     /// Tracks the number of sync signals since this was last sent or received
     sync_counter: AtomicCell<u8>,
     /// The last received data value for an RPDO, or ready to transmit data for a TPDO
-    pub buffered_value: AtomicCell<Option<heapless::Vec<u8, 8>>>,
+    pub buffered_value: AtomicCell<Option<CanMessage>>,
     /// Indicates how many of the values in mapping_params are valid
     ///
     /// This represents sub0 for the mapping object
@@ -382,7 +383,7 @@ impl<'a> Pdo<'a> {
     }
 
     pub(crate) fn send_pdo(&self) {
-        let mut data = [0u8; 8];
+        let mut data = [0u8; MAX_DATA_LENGTH];
         let mut offset = 0;
         let valid_maps = self.valid_maps.load() as usize;
         for (i, param) in self.mapping_params.iter().enumerate() {
@@ -412,9 +413,8 @@ impl<'a> Pdo<'a> {
         }
         // If there is an old value here which has not been sent yet, replace it with the latest
         // Data will be sent by mbox in message handling thread.
-        // Unwrap safety: ensured above that data cannot be longer than 8 bytes
         self.buffered_value
-            .store(Some(heapless::Vec::from_slice(&data[0..offset]).unwrap()));
+            .store(Some(CanMessage::new(self.cob_id(), &data[0..offset])));
     }
 
     /// Lookup a PDO mapped object and create a MappingEntry if it is valid


### PR DESCRIPTION
For what I'm wanting to do it would be useful to have more than the 8 byte data packets that classic CAN allows. I'm not sure if this is the right approach but keen to hear your thoughts on extending the allowed CanMessage length.