### PR TITLE
Support callback when receiving a PDO

### DIFF
--- a/integration_tests/tests/pdo_tests.rs
+++ b/integration_tests/tests/pdo_tests.rs
@@ -34,8 +34,10 @@ async fn test_rpdo_assignment() {
 
     let rpdo_cb_counter: Arc<AtomicU8> = Arc::new(AtomicU8::new(0));
     let rpdo_cb_counter_clone = rpdo_cb_counter.clone();
-    let mut rpdo_received = move |mappings: &[MappingEntry<'_>]| {
+    let mut rpdo_received = move |slot: u8, mappings: &[MappingEntry<'_>]| {
         rpdo_cb_counter_clone.fetch_add(1, Ordering::Relaxed);
+
+        assert_eq!(slot, 0);
 
         assert_eq!(mappings.len(), 2);
 

--- a/integration_tests/tests/pdo_tests.rs
+++ b/integration_tests/tests/pdo_tests.rs
@@ -21,7 +21,7 @@ use zencan_common::{
     traits::{AsyncCanReceiver, AsyncCanSender},
     u24, NodeId,
 };
-use zencan_node::object_dict::ObjectAccess as _;
+use zencan_node::{object_dict::ObjectAccess as _, pdo::MappingEntry};
 
 #[serial]
 #[tokio::test]
@@ -34,10 +34,20 @@ async fn test_rpdo_assignment() {
 
     let rpdo_cb_counter: Arc<AtomicU8> = Arc::new(AtomicU8::new(0));
     let rpdo_cb_counter_clone = rpdo_cb_counter.clone();
-    let mut rpdo_received = move |slot: u8| {
+    let mut rpdo_received = move |mappings: &[MappingEntry<'_>]| {
         rpdo_cb_counter_clone.fetch_add(1, Ordering::Relaxed);
 
-        assert_eq!(slot, 0);
+        assert_eq!(mappings.len(), 2);
+
+        let mapping = &mappings[0];
+        assert_eq!(mapping.object.index, 0x2000);
+        assert_eq!(mapping.sub, 1);
+        assert_eq!(mapping.length, 4);
+        let mapping = &mappings[1];
+        assert_eq!(mapping.object.index, 0x300C);
+        assert_eq!(mapping.sub, 12);
+        assert_eq!(mapping.length, 3);
+
         assert_eq!(OBJECT2000.read_u32(1), Ok(500));
         assert_eq!(OBJECT300C.read_u24(12), Ok(u24::new(0x010203)));
     };

--- a/integration_tests/tests/pdo_tests.rs
+++ b/integration_tests/tests/pdo_tests.rs
@@ -1,7 +1,13 @@
 //! Test node PDO operations
 //!
 
-use std::time::Duration;
+use std::{
+    sync::{
+        atomic::{AtomicU8, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
 
 use integration_tests::{object_dict1, prelude::*};
 use serial_test::serial;
@@ -25,7 +31,21 @@ async fn test_rpdo_assignment() {
 
     let mut bus = SimBus::new();
     bus.add_node(&NODE_MBOX);
-    let callbacks = Callbacks::new();
+
+    let rpdo_cb_counter: Arc<AtomicU8> = Arc::new(AtomicU8::new(0));
+    let rpdo_cb_counter_clone = rpdo_cb_counter.clone();
+    let mut rpdo_received = move |slot: u8| {
+        rpdo_cb_counter_clone.fetch_add(1, Ordering::Relaxed);
+
+        assert_eq!(slot, 0);
+        assert_eq!(OBJECT2000.read_u32(1), Ok(500));
+        assert_eq!(OBJECT300C.read_u24(12), Ok(u24::new(0x010203)));
+    };
+
+    let callbacks = Callbacks {
+        pdo_received: Some(&mut rpdo_received),
+        ..Default::default()
+    };
     let mut node = Node::new(
         NodeId::new(NODE_ID).unwrap(),
         callbacks,
@@ -96,11 +116,14 @@ async fn test_rpdo_assignment() {
         // Delay a bit, because node process() method has to be called for PDO to apply
         ctx.wait_for_process(1).await;
         // Readback the mapped object; the PDO message above should have updated it
+        // These are also checked by the RPDO callback, but we confirm we also can read them via SDO
         assert_eq!(500, client.read_u32(0x2000, 1).await.unwrap());
         assert_eq!(
             u24::new(0x010203),
             client.read_u24(0x300C, 12).await.unwrap()
         );
+        // Check callback was called at least once
+        assert_eq!(rpdo_cb_counter.load(Ordering::Relaxed), 1);
     };
 
     test_with_background_process(&mut [&mut node], &mut bus, test_task).await;

--- a/zencan-node/src/node.rs
+++ b/zencan-node/src/node.rs
@@ -29,7 +29,7 @@ pub type StoreNodeConfigFn<'a> = dyn FnMut(NodeId) + 'a;
 pub type StoreObjectsFn<'a> = dyn Fn(&mut dyn embedded_io::Read<Error = Infallible>, usize) + 'a;
 pub type StateChangeFn<'a> = dyn FnMut(&'a [ODEntry<'a>]) + 'a;
 pub type SyncReceiveFn<'a> = dyn FnMut(SyncObject) + 'a;
-pub type PdoReceiveFn<'a> = dyn for<'b> FnMut(&'b [MappingEntry<'a>]);
+pub type PdoReceiveFn<'a> = dyn for<'b> FnMut(u8, &'b [MappingEntry<'a>]);
 
 /// Collection of callbacks events which Node object can call.
 ///
@@ -379,7 +379,7 @@ impl<'a> Node<'a> {
                             .map(Option::unwrap)
                             .collect();
 
-                        (*cb)(mapping.as_slice());
+                        (*cb)(i as u8, mapping.as_slice());
                     }
                     update_flag = true;
                 }

--- a/zencan-node/src/node.rs
+++ b/zencan-node/src/node.rs
@@ -10,17 +10,18 @@ use zencan_common::{
         CanId, CanMessage, Heartbeat, NmtCommandSpecifier, SyncObject, ZencanMessage, LSS_RESP_ID,
     },
     nmt::NmtState,
-    NodeId,
+    AtomicCell, NodeId,
 };
 
-use crate::sdo_server::SdoServer;
 use crate::{
     lss_slave::{LssConfig, LssSlave},
     node_mbox::NodeMbox,
     node_state::NmtStateAccess as _,
     object_dict::{find_object, ODEntry},
+    pdo::N_MAPPING_PARAMS,
     NodeState,
 };
+use crate::{pdo::MappingEntry, sdo_server::SdoServer};
 
 use defmt_or_log::{debug, info};
 
@@ -28,7 +29,7 @@ pub type StoreNodeConfigFn<'a> = dyn FnMut(NodeId) + 'a;
 pub type StoreObjectsFn<'a> = dyn Fn(&mut dyn embedded_io::Read<Error = Infallible>, usize) + 'a;
 pub type StateChangeFn<'a> = dyn FnMut(&'a [ODEntry<'a>]) + 'a;
 pub type SyncReceiveFn<'a> = dyn FnMut(SyncObject) + 'a;
-pub type PdoReceiveFn<'a> = dyn FnMut(u8);
+pub type PdoReceiveFn<'a> = dyn for<'b> FnMut(&'b [MappingEntry<'a>]);
 
 /// Collection of callbacks events which Node object can call.
 ///
@@ -371,7 +372,14 @@ impl<'a> Node<'a> {
                 if let Some(new_data) = rpdo.buffered_value.take() {
                     rpdo.store_pdo_data(&new_data);
                     if let Some(cb) = &mut self.callbacks.pdo_received {
-                        (*cb)(i as u8);
+                        let mapping: heapless::Vec<MappingEntry<'a>, N_MAPPING_PARAMS> = rpdo
+                            .mapping_params[..rpdo.valid_maps.load().into()]
+                            .iter()
+                            .map(AtomicCell::load)
+                            .map(Option::unwrap)
+                            .collect();
+
+                        (*cb)(mapping.as_slice());
                     }
                     update_flag = true;
                 }

--- a/zencan-node/src/node.rs
+++ b/zencan-node/src/node.rs
@@ -28,6 +28,7 @@ pub type StoreNodeConfigFn<'a> = dyn FnMut(NodeId) + 'a;
 pub type StoreObjectsFn<'a> = dyn Fn(&mut dyn embedded_io::Read<Error = Infallible>, usize) + 'a;
 pub type StateChangeFn<'a> = dyn FnMut(&'a [ODEntry<'a>]) + 'a;
 pub type SyncReceiveFn<'a> = dyn FnMut(SyncObject) + 'a;
+pub type PdoReceiveFn<'a> = dyn FnMut(u8);
 
 /// Collection of callbacks events which Node object can call.
 ///
@@ -77,6 +78,9 @@ pub struct Callbacks<'a> {
 
     /// The node has received a SYNC object
     pub sync_received: Option<&'a mut SyncReceiveFn<'a>>,
+
+    /// The node has received a PDO
+    pub pdo_received: Option<&'a mut PdoReceiveFn<'a>>,
 }
 
 impl<'a> Callbacks<'a> {
@@ -91,6 +95,7 @@ impl<'a> Callbacks<'a> {
             enter_stopped: None,
             enter_preoperational: None,
             sync_received: None,
+            pdo_received: None,
         }
     }
 }
@@ -359,12 +364,15 @@ impl<'a> Node<'a> {
                 pdo.clear_events();
             }
 
-            for rpdo in self.state.rpdos() {
+            for (i, rpdo) in self.state.rpdos().iter().enumerate() {
                 if !rpdo.valid() {
                     continue;
                 }
                 if let Some(new_data) = rpdo.buffered_value.take() {
                     rpdo.store_pdo_data(&new_data);
+                    if let Some(cb) = &mut self.callbacks.pdo_received {
+                        (*cb)(i as u8);
+                    }
                     update_flag = true;
                 }
             }

--- a/zencan-node/src/object_dict/objects.rs
+++ b/zencan-node/src/object_dict/objects.rs
@@ -1,9 +1,10 @@
 //! Traits and types for implementing objects in the OD
 
 use zencan_common::{
+    i24,
     objects::{AccessType, DataType, ObjectCode, SubInfo},
     sdo::AbortCode,
-    AtomicCell,
+    u24, AtomicCell,
 };
 
 use super::{ObjectFlagAccess, SubObjectAccess};
@@ -168,6 +169,13 @@ pub trait ObjectAccess: Sync + Send {
         Ok(u32::from_le_bytes(buf))
     }
 
+    /// Read a sub object as a u24
+    fn read_u24(&self, sub: u8) -> Result<u24, AbortCode> {
+        let mut buf = [0; 3];
+        self.read(sub, 0, &mut buf)?;
+        Ok(u24::from_le_bytes(buf))
+    }
+
     /// Read a sub object as a u16
     fn read_u16(&self, sub: u8) -> Result<u16, AbortCode> {
         let mut buf = [0; 2];
@@ -187,6 +195,13 @@ pub trait ObjectAccess: Sync + Send {
         let mut buf = [0; 4];
         self.read(sub, 0, &mut buf)?;
         Ok(i32::from_le_bytes(buf))
+    }
+
+    /// Read a sub object as an i24
+    fn read_i24(&self, sub: u8) -> Result<i24, AbortCode> {
+        let mut buf = [0; 3];
+        self.read(sub, 0, &mut buf)?;
+        Ok(i24::from_le_bytes(buf))
     }
 
     /// Read a sub object as an i16

--- a/zencan-node/src/pdo.rs
+++ b/zencan-node/src/pdo.rs
@@ -60,6 +60,7 @@ use zencan_common::{
 /// objects to a single PDO
 pub const N_MAPPING_PARAMS: usize = 8;
 
+#[allow(missing_debug_implementations)]
 #[derive(Clone, Copy)]
 /// Data structure for storing a PDO object mapping
 pub struct MappingEntry<'a> {

--- a/zencan-node/src/pdo.rs
+++ b/zencan-node/src/pdo.rs
@@ -58,11 +58,11 @@ use zencan_common::{
 ///
 /// Since we do not yet support CAN-FD, or sub-byte mapping, it's not possible to map more than 8
 /// objects to a single PDO
-const N_MAPPING_PARAMS: usize = 8;
+pub const N_MAPPING_PARAMS: usize = 8;
 
 #[derive(Clone, Copy)]
 /// Data structure for storing a PDO object mapping
-struct MappingEntry<'a> {
+pub struct MappingEntry<'a> {
     /// A reference to the object which is mapped
     pub object: &'a ODEntry<'a>,
     /// The index of the sub object mapped
@@ -196,11 +196,11 @@ pub struct Pdo<'a> {
     /// Indicates how many of the values in mapping_params are valid
     ///
     /// This represents sub0 for the mapping object
-    valid_maps: AtomicCell<u8>,
+    pub valid_maps: AtomicCell<u8>,
     /// The mapping parameters
     ///
     /// These specify which objects are
-    mapping_params: [AtomicCell<Option<MappingEntry<'a>>>; N_MAPPING_PARAMS],
+    pub mapping_params: [AtomicCell<Option<MappingEntry<'a>>>; N_MAPPING_PARAMS],
     /// System default values for this PDO
     defaults: Option<&'a PdoDefaults<'a>>,
 }


### PR DESCRIPTION
Initial attempt exposing the slot of the PDO being received

Ideally, I would like to provide  `&'a [MappingEntry]` for the PDO but I am struggling with the current types

```rust
pub struct Pdo<'a> {
    // ... Skipped ...

    /// The mapping parameters
    ///
    /// These specify which objects are
    mapping_params: [AtomicCell<Option<MappingEntry<'a>>>; N_MAPPING_PARAMS],
}
```

